### PR TITLE
Allow to use arbitrary partials

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   futurism!
+  nokogiri
   pry (~> 0.12.2)
   rake (~> 13.0)
   spy

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Lazy-load Rails partials via CableReady
 with a helper in your template
 
 ```erb
-<%= futurize @posts %>
+<%= futurize @posts, extends: :div do %>
+  <!-- placeholder -->
+<% end %>
 ```
 
 custom `<futurism-element>`s (in the form of a `<div>` or a `<tr is="futurism-table-row">` are rendered. Those custom elements have an `IntersectionObserver` attached that will send a signed global id to an ActionCable channel (`FuturismChannel`) which will then replace the placeholders with the actual resource partial.
@@ -30,7 +32,21 @@ You can pass the placeholder as a block:
 
 ![aa601dec1930151f71dbf0d6b02b61c9](https://user-images.githubusercontent.com/4352208/87131629-f768a480-c294-11ea-89a9-ea0a76ee06ef.gif)
 
-### Partial Path
+## API
+
+Currently there are two ways to call `futurize`, designed to wrap `render`'s behavior:
+
+### Resource
+
+You can pass a single `ActiveRecord` or an `ActiveRecord::Relation` to `futurize`, just as you would call `render`:
+
+```erb
+<%= futurize @posts, extends: :tr do %>
+  <td class="placeholder"></td>
+<% end %>
+```
+
+#### Partial Path
 
 Remember that you can override the partial path in you models, like so:
 
@@ -41,6 +57,17 @@ class Post < ApplicationRecord
   end
 end
 ```
+
+### Explicit Partial
+
+Call `futurize` with a `partial` keyword:
+
+```erb
+<%= futurize partial: "items/card", locals: {card: @card} %>
+  <div class="spinner"></div>
+<% end %>
+```
+
 
 That way you get maximal flexibility when just specifying a single resource.
 
@@ -62,7 +89,7 @@ To copy over the javascript files to your application, run
 $ bin/rails futurism:install
 ```
 
-** ! Note that the installer will run `yarn install @minthesize/futurism` for you ! **
+**! Note that the installer will run `yarn install @minthesize/futurism` for you !**
 
 ### Manual Installation
 After `bundle`, install the Javascript library:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 Lazy-load Rails partials via CableReady
 
+:rotating_light: *Futurism is still in pre-1.0 state. As much as I hope to keep the API backwards-compatible, I cannot guarantee it* :rotating_light:
+
 ## Facts
 - only one dependency: CableReady
 - bundle size (without CableReady) is around [~1.04kB](https://bundlephobia.com/result?p=@minthesize/futurism@0.1.3)
@@ -68,18 +70,24 @@ class Post < ApplicationRecord
 end
 ```
 
+That way you get maximal flexibility when just specifying a single resource.
+
 ### Explicit Partial
 
 Call `futurize` with a `partial` keyword:
 
 ```erb
-<%= futurize partial: "items/card", locals: {card: @card} %>
+<%= futurize partial: "items/card", locals: {card: @card}, extends: :div %>
   <div class="spinner"></div>
 <% end %>
 ```
 
+You can also use the shorthand syntax:
 
-That way you get maximal flexibility when just specifying a single resource.
+```erb
+<%= futurize "items/card", card: @card, extends: :div %>
+  <div class="spinner"></div>
+<% end %>
 
 ## Installation
 Add this line to your application's Gemfile:

--- a/futurism.gemspec
+++ b/futurism.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "pry", "~> 0.12.2"
+  spec.add_development_dependency "nokogiri"
   spec.add_development_dependency "standardrb"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "spy"

--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -24,10 +24,12 @@ const polyfillCustomElements = () => {
 }
 
 const defineElements = e => {
-  customElements.define('futurism-element', FuturismElement)
-  customElements.define('futurism-table-row', FuturismTableRow, {
-    extends: 'tr'
-  })
+  if (!customElements.get('futurism-element')) {
+    customElements.define('futurism-element', FuturismElement)
+    customElements.define('futurism-table-row', FuturismTableRow, {
+      extends: 'tr'
+    })
+  }
 }
 
 export const initializeElements = () => {

--- a/javascript/futurism_channel.js
+++ b/javascript/futurism_channel.js
@@ -21,7 +21,9 @@ export const createSubscription = consumer => {
       document.addEventListener(
         'futurism:appear',
         debounceEvents(events => {
-          this.send({ sgids: events.map(e => e.target.dataset.sgid) })
+          this.send({
+            signed_params: events.map(e => e.target.dataset.signedParams)
+          })
         })
       )
     },

--- a/javascript/futurism_channel.js
+++ b/javascript/futurism_channel.js
@@ -1,6 +1,6 @@
 import CableReady from 'cable_ready'
 
-const debounceEvents = (callback, delay = 250) => {
+const debounceEvents = (callback, delay = 20) => {
   let timeoutId
   let events = []
   return (...args) => {

--- a/lib/futurism.rb
+++ b/lib/futurism.rb
@@ -6,6 +6,10 @@ require "futurism/channel"
 require "futurism/helpers"
 
 module Futurism
+  extend ActiveSupport::Autoload
+
+  autoload :Helpers, "futurism/helpers"
+
   ActiveSupport.on_load(:action_view) {
     include Futurism::Helpers
   }

--- a/lib/futurism/channel.rb
+++ b/lib/futurism/channel.rb
@@ -11,6 +11,8 @@ module Futurism
         [signed_params, Rails.application.message_verifier("futurism").verify(signed_params)]
       }
 
+      ApplicationController.renderer.instance_variable_set(:@env, connection.env)
+
       resources.each do |signed_params, resource|
         cable_ready["Futurism::Channel"].outer_html(
           selector: "[data-signed-params='#{signed_params}']",

--- a/lib/futurism/channel.rb
+++ b/lib/futurism/channel.rb
@@ -7,13 +7,13 @@ module Futurism
     end
 
     def receive(data)
-      resources = data["sgids"].map { |sgid|
-        [sgid, GlobalID::Locator.locate_signed(sgid)]
+      resources = data["signed_params"].map { |signed_params|
+        [signed_params, Rails.application.message_verifier("futurism").verify(signed_params)]
       }
 
-      resources.each do |sgid, resource|
+      resources.each do |signed_params, resource|
         cable_ready["Futurism::Channel"].outer_html(
-          selector: "[data-sgid='#{sgid}']",
+          selector: "[data-signed-params='#{signed_params}']",
           html: ApplicationController.render(resource)
         )
       end

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -1,10 +1,12 @@
 module Futurism
   module Helpers
-    def futurize(records = nil, extends:, **options, &block)
+    def futurize(records_or_string = nil, extends:, **options, &block)
       placeholder = capture(&block)
 
-      if records.is_a?(ActiveRecord::Base) || records.is_a?(ActiveRecord::Relation)
-        futurize_active_record(records, extends: extends, placeholder: placeholder)
+      if records_or_string.is_a?(ActiveRecord::Base) || records_or_string.is_a?(ActiveRecord::Relation)
+        futurize_active_record(records_or_string, extends: extends, placeholder: placeholder)
+      elsif records_or_string.is_a?(String)
+        futurize_with_options(extends: extends, partial: records_or_string, locals: options, placeholder: placeholder)
       else
         futurize_with_options(extends: extends, placeholder: placeholder, **options)
       end
@@ -19,8 +21,8 @@ module Futurism
       end
     end
 
-    def futurize_active_record(records, extends:, placeholder:)
-      Array(records).map { |record|
+    def futurize_active_record(records_or_string, extends:, placeholder:)
+      Array(records_or_string).map { |record|
         case extends
         when :tr
           content_tag :tr, placeholder, data: {signed_params: futurism_signed_params(record)}, is: "futurism-table-row"

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -33,7 +33,7 @@ module Futurism
     end
 
     def futurism_signed_params(params)
-      Rails.application.message_verifier("futurism").generate(params, expires_in: 1.hour)
+      Rails.application.message_verifier("futurism").generate(params)
     end
   end
 end

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -1,7 +1,25 @@
 module Futurism
   module Helpers
-    def futurize(records, extends:, &block)
+    def futurize(records = nil, extends:, **options, &block)
       placeholder = capture(&block)
+
+      if records.is_a?(ActiveRecord::Base) || records.is_a?(ActiveRecord::Relation)
+        futurize_active_record(records, extends: extends, placeholder: placeholder)
+      else
+        futurize_with_options(extends: extends, placeholder: placeholder, **options)
+      end
+    end
+
+    def futurize_with_options(extends:, placeholder:, **options)
+      case extends
+      when :tr
+        content_tag :tr, placeholder, data: {signed_params: futurism_signed_params(options)}, is: "futurism-table-row"
+      else
+        content_tag :"futurism-element", placeholder, data: {signed_params: futurism_signed_params(options)}
+      end
+    end
+
+    def futurize_active_record(records, extends:, placeholder:)
       Array(records).map { |record|
         case extends
         when :tr
@@ -13,7 +31,7 @@ module Futurism
     end
 
     def futurism_signed_params(params)
-      Rails.application.message_verifier("futurism").generate(params)
+      Rails.application.message_verifier("futurism").generate(params, expires_in: 1.hour)
     end
   end
 end

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -5,11 +5,15 @@ module Futurism
       Array(records).map { |record|
         case extends
         when :tr
-          content_tag :tr, placeholder, data: {sgid: record.to_sgid.to_s}, is: "futurism-table-row"
+          content_tag :tr, placeholder, data: {signed_params: futurism_signed_params(record)}, is: "futurism-table-row"
         else
-          content_tag :"futurism-element", placeholder, data: {sgid: record.to_sgid.to_s}
+          content_tag :"futurism-element", placeholder, data: {signed_params: futurism_signed_params(record)}
         end
       }.join.html_safe
+    end
+
+    def futurism_signed_params(params)
+      Rails.application.message_verifier("futurism").generate(params)
     end
   end
 end

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -21,8 +21,8 @@ module Futurism
       end
     end
 
-    def futurize_active_record(records_or_string, extends:, placeholder:)
-      Array(records_or_string).map { |record|
+    def futurize_active_record(records, extends:, placeholder:)
+      Array(records).map { |record|
         case extends
         when :tr
           content_tag :tr, placeholder, data: {signed_params: futurism_signed_params(record)}, is: "futurism-table-row"

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -22,6 +22,18 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     assert renderer_spy.has_been_called_with? post
   end
 
+  test "broadcasts an ActiveRecord::Relation" do
+    renderer_spy = Spy.on(ApplicationController, :render)
+    Post.create title: "Lorem"
+    Post.create title: "Ipsum"
+    signed_params = futurism_signed_params(Post.all)
+    subscribe
+
+    perform :receive, {"signed_params" => [signed_params]}
+
+    assert renderer_spy.has_been_called_with? Post.all
+  end
+
   test "broadcasts a rendered partial after receiving signed params" do
     renderer_spy = Spy.on(ApplicationController, :render)
     post = Post.create title: "Lorem"

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Futurism::ChannelTest < ActionCable::Channel::TestCase
+  include Futurism::Helpers
+
   test "subscribed" do
     subscribe
 
@@ -9,13 +11,13 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     assert_has_stream "Futurism::Channel"
   end
 
-  test "broadcasts after receiving sgids" do
+  test "broadcasts a rendered model after receiving signed params" do
     renderer_spy = Spy.on(ApplicationController, :render)
     post = Post.create title: "Lorem"
-    sgid = post.to_sgid.to_s
+    signed_params = futurism_signed_params(post)
     subscribe
 
-    perform :receive, {"sgids" => [sgid]}
+    perform :receive, {"signed_params" => [signed_params]}
 
     assert renderer_spy.has_been_called_with? post
   end

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -5,6 +5,10 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   include ActionView::Helpers
   include ActionView::Context
 
+  setup do
+    stub_connection(env: {})
+  end
+
   test "subscribed" do
     subscribe
 

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -21,4 +21,15 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
 
     assert renderer_spy.has_been_called_with? post
   end
+
+  test "broadcasts a rendered partial after receiving signed params" do
+    renderer_spy = Spy.on(ApplicationController, :render)
+    post = Post.create title: "Lorem"
+    signed_params = futurism_signed_params(partial: "posts/card", locals: {post: post})
+    subscribe
+
+    perform :receive, {"signed_params" => [signed_params]}
+
+    assert renderer_spy.has_been_called_with?(partial: "posts/card", locals: {post: post})
+  end
 end

--- a/test/dummy/app/views/posts/_card.html.erb
+++ b/test/dummy/app/views/posts/_card.html.erb
@@ -1,0 +1,3 @@
+<div class="card">
+  <%= post.title %>
+</div>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] = "test"
 
 require_relative "../test/dummy/config/environment"
 require "rails/test_help"
+require "nokogiri"
 require "pry"
 require "spy/integration"
 


### PR DESCRIPTION
# Feature

## Description

Allows `futurize` to be called with a `partial` keyword

Changed the internal implementation to use `ActiveSupport::MessageVerifier`

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
