### PR TITLE
Dispatch futurism:appear method

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Collection rendering is also possible:
 <% end %>
 ```
 
+## Events
+
+Once your futurize element has been rendered, the `futurize:appeared` custom event will be called.
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/javascript/futurism_channel.js
+++ b/javascript/futurism_channel.js
@@ -33,6 +33,10 @@ export const createSubscription = consumer => {
         CableReady.perform(data.operations, {
           emitMissingElementWarnings: false
         })
+        
+        document.dispatchEvent(
+          new CustomEvent('futurism:appear', { bubbles: true, cancelable: true })
+        )
       }
     }
   })

--- a/javascript/futurism_channel.js
+++ b/javascript/futurism_channel.js
@@ -1,3 +1,5 @@
+/* global CustomEvent, setTimeout */
+
 import CableReady from 'cable_ready'
 
 const debounceEvents = (callback, delay = 20) => {

--- a/javascript/futurism_channel.js
+++ b/javascript/futurism_channel.js
@@ -37,7 +37,7 @@ export const createSubscription = consumer => {
         })
         
         document.dispatchEvent(
-          new CustomEvent('futurism:appear', { bubbles: true, cancelable: true })
+          new CustomEvent('futurism:appeared', { bubbles: true, cancelable: true })
         )
       }
     }


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

enhancement

## Description

Whenever data is received and CableReady has performed its actions, dispatch the `futurism:appear` event.

Note: I'm not certain if this is exactly what you had in mind, so I am open to any suggestions. I just think this is a great library and wanted to help quickly.

Fixes # (issue)

Resolves #19 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing
