### PR TITLE
enable passing of html_options hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,24 @@ You can also use the shorthand syntax:
 <% end %>
 ```
 
+### HTML Options
+
+You can pass a hash of attribute/value pairs which will be mixed into the HTML markup for the placeholder element. This is important for layouts that require elements to have dimensionality. For example, many scripts calculate size based on element height and width. This option ensures that your elements have integrity, even if they are gone before you see them.
+
+```erb
+<%= futurize @posts, extends: :tr, html_options: {style: "width: 50px; height: 50px;"} do %>
+  <td class="placeholder"></td>
+<% end %>
+```
+
+This will output the following:
+
+```html
+<tr style="width: 50px; height: 50px;">
+  <td class="placeholder"></td>
+</tr>
+```
+
 #### Collections
 
 Collection rendering is also possible:

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -4,7 +4,7 @@ module Futurism
       placeholder = capture(&block)
 
       if records_or_string.is_a?(ActiveRecord::Base) || records_or_string.is_a?(ActiveRecord::Relation)
-        futurize_active_record(records_or_string, extends: extends, placeholder: placeholder)
+        futurize_active_record(records_or_string, extends: extends, placeholder: placeholder, **options)
       elsif records_or_string.is_a?(String)
         futurize_with_options(extends: extends, partial: records_or_string, locals: options, placeholder: placeholder)
       else
@@ -24,20 +24,22 @@ module Futurism
       end
     end
 
-    def futurize_active_record(records, extends:, placeholder:)
+    def futurize_active_record(records, extends:, placeholder:, **options)
       Array(records).map { |record|
-        render_element(extends: extends, placeholder: placeholder, options: record)
+        render_element(extends: extends, placeholder: placeholder, options: options.merge(model: record))
       }.join.html_safe
     end
 
     def render_element(extends:, options:, placeholder:)
+      html_options = options.delete(:html_options) || {}
+      options = options.delete(:model) || options
       case extends
       when :li
-        content_tag :li, placeholder, data: {signed_params: futurism_signed_params(options)}, is: "futurism-li"
+        content_tag :li, placeholder, {data: {signed_params: futurism_signed_params(options)}, is: "futurism-li"}.merge(html_options)
       when :tr
-        content_tag :tr, placeholder, data: {signed_params: futurism_signed_params(options)}, is: "futurism-table-row"
+        content_tag :tr, placeholder, {data: {signed_params: futurism_signed_params(options)}, is: "futurism-table-row"}.merge(html_options)
       else
-        content_tag :"futurism-element", placeholder, data: {signed_params: futurism_signed_params(options)}
+        content_tag :"futurism-element", placeholder, {data: {signed_params: futurism_signed_params(options)}}.merge(html_options)
       end
     end
 

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -32,14 +32,14 @@ module Futurism
 
     def render_element(extends:, options:, placeholder:)
       html_options = options.delete(:html_options) || {}
-      options = options.delete(:model) || options
+      model_or_options = options.delete(:model) || options
       case extends
       when :li
-        content_tag :li, placeholder, {data: {signed_params: futurism_signed_params(options)}, is: "futurism-li"}.merge(html_options)
+        content_tag :li, placeholder, {data: {signed_params: futurism_signed_params(model_or_options)}, is: "futurism-li"}.merge(html_options)
       when :tr
-        content_tag :tr, placeholder, {data: {signed_params: futurism_signed_params(options)}, is: "futurism-table-row"}.merge(html_options)
+        content_tag :tr, placeholder, {data: {signed_params: futurism_signed_params(model_or_options)}, is: "futurism-table-row"}.merge(html_options)
       else
-        content_tag :"futurism-element", placeholder, {data: {signed_params: futurism_signed_params(options)}}.merge(html_options)
+        content_tag :"futurism-element", placeholder, {data: {signed_params: futurism_signed_params(model_or_options)}}.merge(html_options)
       end
     end
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

All calls to the `futurize` helper now accept a new parameter, `html_options` which is a hash. This gets passed directly to `content_tag`.

eg.

```html
<%= futurize @posts, extends: :tr, html_options: {style: "color: red"} do %>
  <td class="placeholder">&nbsp;</td>
<% end %>
```

will produce:

```html
<tr data-signed-params="BAhvOglQb3N0EDoQQG5ld19yZWNvcmRGOhBAYXR0cmlidXRlc286HkFjdGl2ZU1vZGVsOjpBdHRyaWJ1dGVTZXQGOwdVOiNBY3RpdmVNb2RlbDo6TGF6eUF0dHJpYnV0ZUhhc2hbCn0JSSIHaWQGOgZFVG86H0FjdGl2ZU1vZGVsOjpUeXBlOjpJbnRlZ2VyCToPQHByZWNpc2lvbjA6C0BzY2FsZTA6C0BsaW1pdGkNOgtAcmFuZ2VvOgpSYW5nZQg6CWV4Y2xUOgpiZWdpbmwtCQAAAAAAAACAOghlbmRsKwkAAAAAAAAAgEkiCnRpdGxlBjsKVG86HkFjdGl2ZU1vZGVsOjpUeXBlOjpTdHJpbmcIOwwwOw0wOw4wSSIPY3JlYXRlZF9hdAY7ClRVOkpBY3RpdmVSZWNvcmQ6OkF0dHJpYnV0ZU1ldGhvZHM6OlRpbWVab25lQ29udmVyc2lvbjo6VGltZVpvbmVDb252ZXJ0ZXJbCToLX192Ml9fWwBbAG86QEFjdGl2ZVJlY29yZDo6Q29ubmVjdGlvbkFkYXB0ZXJzOjpQb3N0Z3JlU1FMOjpPSUQ6OkRhdGVUaW1lCDsMaQs7DTA7DjBJIg91cGRhdGVkX2F0BjsKVFU7FVsJOxZbAFsAQBZvOh1BY3RpdmVNb2RlbDo6VHlwZTo6VmFsdWUIOwwwOw0wOw4wewlJIgdpZAY7ClRpeEkiCnRpdGxlBjsKVEkiD0Vsb3kgV29sZmYGOwpUSSIPY3JlYXRlZF9hdAY7ClRJdToJVGltZQ11GR7AxBIddAY6CXpvbmVJIghVVEMGOwpGSSIPdXBkYXRlZF9hdAY7ClRJdTsZDXUZHsDEEh10BjsaQCJ7AHsGQApvOilBY3RpdmVNb2RlbDo6QXR0cmlidXRlOjpGcm9tRGF0YWJhc2UJOgpAbmFtZUAKOhxAdmFsdWVfYmVmb3JlX3R5cGVfY2FzdDA6CkB0eXBlQAs6GEBvcmlnaW5hbF9hdHRyaWJ1dGUwewlACm87Gwo7HEAKOx1peDseQAs7HzA6C0B2YWx1ZWl4QA9vOxsKOxxADzsdQCA7HkAQOx8wOyBJIg9FbG95IFdvbGZmBjsKVEARbzsbCjscQBE7HUAjOx5AEjsfMDsgVTogQWN0aXZlU3VwcG9ydDo6VGltZVdpdGhab25lWwhAI0kiCFVUQwY7ClRAI0AXbzsbCjscQBc7HUAlOx5AGDsfMDsgVTshWwhAJUAwQCU6F0Bhc3NvY2lhdGlvbl9jYWNoZXsAOhFAcHJpbWFyeV9rZXlJIgdpZAY7ClQ6DkByZWFkb25seUY6D0BkZXN0cm95ZWRGOhxAbWFya2VkX2Zvcl9kZXN0cnVjdGlvbkY6HkBkZXN0cm95ZWRfYnlfYXNzb2NpYXRpb24wOh5AX3N0YXJ0X3RyYW5zYWN0aW9uX3N0YXRlMDoXQHRyYW5zYWN0aW9uX3N0YXRlMDoXQGluc3BlY3Rpb25fZmlsdGVybzojQWN0aXZlU3VwcG9ydDo6UGFyYW1ldGVyRmlsdGVyCDoNQGZpbHRlcnNbBjoNcGFzc3dvcmQ6CkBtYXNrVTonQWN0aXZlUmVjb3JkOjpDb3JlOjpJbnNwZWN0aW9uTWFza1sJOxZbAFsASSIPW0ZJTFRFUkVEXQY7ClQ6FUBjb21waWxlZF9maWx0ZXJvOjNBY3RpdmVTdXBwb3J0OjpQYXJhbWV0ZXJGaWx0ZXI6OkNvbXBpbGVkRmlsdGVyCToNQHJlZ2V4cHNbBkkvDXBhc3N3b3JkAQY7CkY6EkBkZWVwX3JlZ2V4cHMwOgxAYmxvY2tzWwA7LkA4--2b48904b0251e074f7c718ef2d7737e7bd4ce555" is="futurism-table-row" style="color: red">
  <td class="placeholder">&nbsp;</td>
</tr>
```

## Why should this be added

Layouts might require placeholder elements to have CSS classes or styles to enforce layout. Some scripts also make calculations based on dimensions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
