### PR TITLE
Allow to pass locals when rendering a collection

### DIFF
--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -19,7 +19,7 @@ module Futurism
       else
         collection_class_name = collection.first.class.name
         collection.map { |record|
-          render_element(extends: extends, placeholder: placeholder, options: options.merge(locals: {collection_class_name.downcase.to_sym => record}))
+          render_element(extends: extends, placeholder: placeholder, options: options.deep_merge(locals: {collection_class_name.downcase.to_sym => record}))
         }.join.html_safe
       end
     end

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -74,7 +74,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     renderer_spy = Spy.on(ApplicationController, :render)
     Post.create title: "Lorem"
     Post.create title: "Ipsum"
-    fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, extends: :div) {})
+    fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, extends: :div, locals: {important_local: "needed to render"}) {})
     signed_params = fragment.children.first["data-signed-params"]
     subscribe
 
@@ -83,7 +83,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     signed_params = fragment.children.last["data-signed-params"]
     perform :receive, {"signed_params" => [signed_params]}
 
-    assert renderer_spy.has_been_called_with?(partial: "posts/card", locals: {post: Post.first})
-    assert renderer_spy.has_been_called_with?(partial: "posts/card", locals: {post: Post.last})
+    assert renderer_spy.has_been_called_with?(partial: "posts/card", locals: {post: Post.first, important_local: "needed to render"})
+    assert renderer_spy.has_been_called_with?(partial: "posts/card", locals: {post: Post.last, important_local: "needed to render"})
   end
 end


### PR DESCRIPTION
# Type of PR 
Feature

## Description

This PR implements the suggested solution as described in #27. It allows pass `locals` when rendering a collection with `futurize`:

```html+erb
<%= futurize partial: 'items/card', collection: @cards, as: :card, extends: :div, locals: { selected: true } do %>
  <div class="spinner"></div>
<% end %>
```

Resolves #27.

## Why should this be added

In order to stay as close as possible to the `render` method in Rails it makes sense to support the passing of locals when rendering a collection.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
