### PR TITLE
uses AR Collection klass method

### DIFF
--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -17,7 +17,7 @@ module Futurism
       if collection.nil?
         render_element(extends: extends, placeholder: placeholder, options: options)
       else
-        collection_class_name = collection.first.class.name
+        collection_class_name = collection.klass.name
         collection.map { |record|
           render_element(extends: extends, placeholder: placeholder, options: options.merge(locals: {collection_class_name.downcase.to_sym => record}))
         }.join.html_safe


### PR DESCRIPTION
## Type of PR (feature, enhancement, bug fix, etc.)
Minor enhancement

## Description
Uses the `#klass` method on a collection to get the class being wrapped.

## Why should this be added
`#klass` returns the collection's class even when it's empty.

```
User.none.first.class.name
=> "NilClass"
User.none.klass.name
=> "User"
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
