### PR TITLE
Allow to specify :as when rendering a collection

### DIFF
--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -18,8 +18,9 @@ module Futurism
         render_element(extends: extends, placeholder: placeholder, options: options)
       else
         collection_class_name = collection.klass.name
+        as = options.delete(:as) || collection_class_name.downcase.to_sym
         collection.map { |record|
-          render_element(extends: extends, placeholder: placeholder, options: options.deep_merge(locals: {collection_class_name.downcase.to_sym => record}))
+          render_element(extends: extends, placeholder: placeholder, options: options.deep_merge(locals: {as => record}))
         }.join.html_safe
       end
     end

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -18,9 +18,9 @@ module Futurism
         render_element(extends: extends, placeholder: placeholder, options: options)
       else
         collection_class_name = collection.klass.name
-        as = options.delete(:as) || collection_class_name.downcase.to_sym
+        as = options.delete(:as) || collection_class_name.downcase
         collection.map { |record|
-          render_element(extends: extends, placeholder: placeholder, options: options.deep_merge(locals: {as => record}))
+          render_element(extends: extends, placeholder: placeholder, options: options.deep_merge(locals: {as.to_sym => record}))
         }.join.html_safe
       end
     end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

This PR allows to specify `:as` when rendering a collection. With this you can name the local variable which is getting passed to your partial.

Example:

```html+erb
<%= futurize partial: 'items/card', collection: @cards, as: :card_item, extends: :div do %>
  <div class="spinner"></div>
<% end %>
```

## Why should this be added

Similar to #28 this PR aims to bring `futurize` closer to the Rails `render` method.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
