### PR TITLE
Update bug report template to feature 'Futurism'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,15 +25,17 @@ If applicable, add screenshots (errors, example of the behavior, etc.) to help e
 
 ## Versions
 
-### StimulusReflex
+### Futurism
 
-- Gem: [e.g. 2.0.1]
-- Node package: [e.g. 2.0.1]
+- Gem: [e.g. 0.3.1]
+- Node package: [e.g. 0.3.1]
 
 ### External tools
 
 - Ruby: [e.g. 2.6.4]
 - Rails: [e.g. 6.0.0]
+- CableReady: [e.g. 4.3.0]
+- StimulusReflex: [e.g. 3.2.0]
 - Node: [e.g. 12.4.0]
 
 ### Browser

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,7 +35,6 @@ If applicable, add screenshots (errors, example of the behavior, etc.) to help e
 - Ruby: [e.g. 2.6.4]
 - Rails: [e.g. 6.0.0]
 - CableReady: [e.g. 4.3.0]
-- StimulusReflex: [e.g. 3.2.0]
 - Node: [e.g. 12.4.0]
 
 ### Browser


### PR DESCRIPTION
# Type of PR

Fix

## Description

Update the bug report template to feature Futurism and CableReady.

## Why should this be added

No confusion when someone tries to file a bug 😉 
Plus it could be good to know what version of CableReady is being used since they are "heavily related".

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
