### PR TITLE
20 fix generated urls

### DIFF
--- a/lib/futurism/channel.rb
+++ b/lib/futurism/channel.rb
@@ -11,7 +11,8 @@ module Futurism
         [signed_params, Rails.application.message_verifier("futurism").verify(signed_params)]
       }
 
-      ApplicationController.renderer.instance_variable_set(:@env, connection.env)
+      new_env = connection.env.merge(ApplicationController.renderer.instance_variable_get(:@env))
+      ApplicationController.renderer.instance_variable_set(:@env, new_env)
 
       resources.each do |signed_params, resource|
         cable_ready["Futurism::Channel"].outer_html(

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -4,6 +4,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   include Futurism::Helpers
   include ActionView::Helpers
   include ActionView::Context
+  include CableReady::Broadcaster
 
   setup do
     stub_connection(env: {})
@@ -102,5 +103,15 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
 
     assert renderer_spy.has_been_called_with?(partial: "posts/card", locals: {post_item: Post.first})
     assert renderer_spy.has_been_called_with?(partial: "posts/card", locals: {post_item: Post.last})
+  end
+
+  test "broadcasts an inline rendered text" do
+    fragment = Nokogiri::HTML.fragment(futurize(inline: "<%= 1 + 2 %>", extends: :div) {})
+    signed_params = fragment.children.first["data-signed-params"]
+    subscribe
+
+    assert_broadcast_on("Futurism::Channel", "cableReady" => true, "operations" => {"outerHtml" => [{"selector" => "[data-signed-params='#{signed_params}']", "html" => "3"}]}) do
+      perform :receive, {"signed_params" => [signed_params]}
+    end
   end
 end

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -7,7 +7,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   include CableReady::Broadcaster
 
   setup do
-    stub_connection(env: { "SCRIPT_NAME" => "/cable"})
+    stub_connection(env: {"SCRIPT_NAME" => "/cable"})
   end
 
   test "subscribed" do

--- a/test/dummy/app/views/posts/_card.html.erb
+++ b/test/dummy/app/views/posts/_card.html.erb
@@ -1,3 +1,4 @@
 <div class="card">
   <%= post.title %>
+  <%= link_to("Edit", edit_post_path(post)) %>
 </div>


### PR DESCRIPTION
Bug fix

## Description

Fixes #20

Url generation in rendered partials should now work. The reason was that the incorrect `SCRIPT_NAME` from `connection.env` was applied here: https://github.com/rails/rails/blob/b13a5cb83ea00d6a3d71320fd276ca21049c2544/actionpack/lib/action_controller/metal/url_for.rb

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
