### PR TITLE
Refactor element - use SGIDs where possible to minimize over-the-wire size

### DIFF
--- a/javascript/futurism_channel.js
+++ b/javascript/futurism_channel.js
@@ -24,7 +24,8 @@ export const createSubscription = consumer => {
         'futurism:appear',
         debounceEvents(events => {
           this.send({
-            signed_params: events.map(e => e.target.dataset.signedParams)
+            signed_params: events.map(e => e.target.dataset.signedParams),
+            sgids: events.map(e => e.target.dataset.sgid)
           })
         })
       )
@@ -35,9 +36,12 @@ export const createSubscription = consumer => {
         CableReady.perform(data.operations, {
           emitMissingElementWarnings: false
         })
-        
+
         document.dispatchEvent(
-          new CustomEvent('futurism:appeared', { bubbles: true, cancelable: true })
+          new CustomEvent('futurism:appeared', {
+            bubbles: true,
+            cancelable: true
+          })
         )
       }
     }

--- a/lib/futurism/channel.rb
+++ b/lib/futurism/channel.rb
@@ -7,21 +7,28 @@ module Futurism
     end
 
     def receive(data)
-      resources = data["signed_params"].map { |signed_params|
-        [signed_params, Rails.application.message_verifier("futurism").verify(signed_params)]
-      }
+      resources = data.fetch_values("signed_params", "sgids") { |key| [nil] }.transpose
 
       new_env = connection.env.merge(ApplicationController.renderer.instance_variable_get(:@env))
       ApplicationController.renderer.instance_variable_set(:@env, new_env)
 
-      resources.each do |signed_params, resource|
+      resources.each do |signed_params, sgid|
+        selector = "[data-signed-params='#{signed_params}']"
         cable_ready["Futurism::Channel"].outer_html(
-          selector: "[data-signed-params='#{signed_params}']",
-          html: ApplicationController.render(resource)
+          selector: selector,
+          html: ApplicationController.render(resource(signed_params: signed_params, sgid: sgid))
         )
       end
 
       cable_ready.broadcast
+    end
+
+    private
+
+    def resource(signed_params:, sgid:)
+      return GlobalID::Locator.locate_signed(sgid) if sgid.present? 
+
+      Rails.application.message_verifier("futurism").verify(signed_params)
     end
   end
 end

--- a/lib/futurism/channel.rb
+++ b/lib/futurism/channel.rb
@@ -13,7 +13,8 @@ module Futurism
       ApplicationController.renderer.instance_variable_set(:@env, new_env)
 
       resources.each do |signed_params, sgid|
-        selector = "[data-signed-params='%s'%s]" % [signed_params, sgid.present? ? " data-sgid='#{sgid}'" : ""]
+        selector = "[data-signed-params='#{signed_params}']"
+        selector << "[data-sgid='#{sgid}']" if sgid.present?
         cable_ready["Futurism::Channel"].outer_html(
           selector: selector,
           html: ApplicationController.render(resource(signed_params: signed_params, sgid: sgid))

--- a/lib/futurism/channel.rb
+++ b/lib/futurism/channel.rb
@@ -13,7 +13,7 @@ module Futurism
       ApplicationController.renderer.instance_variable_set(:@env, new_env)
 
       resources.each do |signed_params, sgid|
-        selector = "[data-signed-params='#{signed_params}']"
+        selector = "[data-signed-params='%s'%s]" % [signed_params, sgid.present? ? " data-sgid='#{sgid}'" : ""]
         cable_ready["Futurism::Channel"].outer_html(
           selector: selector,
           html: ApplicationController.render(resource(signed_params: signed_params, sgid: sgid))
@@ -26,7 +26,7 @@ module Futurism
     private
 
     def resource(signed_params:, sgid:)
-      return GlobalID::Locator.locate_signed(sgid) if sgid.present? 
+      return GlobalID::Locator.locate_signed(sgid) if sgid.present?
 
       Rails.application.message_verifier("futurism").verify(signed_params)
     end

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -15,26 +15,23 @@ module Futurism
     def futurize_with_options(extends:, placeholder:, **options)
       collection = options.delete(:collection)
       if collection.nil?
-        render_element(extends: extends, placeholder: placeholder, options: options)
+        Element.new(extends: extends, placeholder: placeholder, options: options).render
       else
         collection_class_name = collection.klass.name
         as = options.delete(:as) || collection_class_name.downcase
         collection.map { |record|
-          render_element(extends: extends, placeholder: placeholder, options: options.deep_merge(locals: {as.to_sym => record}))
+          Element.new(extends: extends, placeholder: placeholder, options: options.deep_merge(locals: {as.to_sym => record})).render
         }.join.html_safe
       end
     end
 
     def futurize_active_record(records, extends:, placeholder:, **options)
       Array(records).map { |record|
-        render_element(extends: extends, placeholder: placeholder, options: options.merge(model: record))
+        Element.new(extends: extends, options: options.merge(model: record), placeholder: placeholder).render
       }.join.html_safe
     end
 
-    def render_element(extends:, options:, placeholder:)
-      Element.new(extends: extends, options: options, placeholder: placeholder).render
-    end
-
+    # wraps functionality for rendering a futurism element
     class Element
       include ActionView::Helpers
 

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -35,30 +35,38 @@ module Futurism
     class Element
       include ActionView::Helpers
 
-      attr_reader :extends, :placeholder, :html_options, :model_or_options
+      attr_reader :extends, :placeholder, :html_options, :model, :options
 
       def initialize(extends:, placeholder:, options:)
         @extends = extends
         @placeholder = placeholder
         @html_options = options.delete(:html_options) || {}
-        @model_or_options = options.delete(:model) || options
+        @model = options.delete(:model)
+        @options = options
+      end
+
+      def dataset
+        {
+          signed_params: signed_params,
+          sgid: model && model.to_sgid.to_s
+        }
       end
 
       def render
         case extends
         when :li
-          content_tag :li, placeholder, {data: {signed_params: signed_params(model_or_options)}, is: "futurism-li"}.merge(html_options)
+          content_tag :li, placeholder, {data: dataset, is: "futurism-li"}.merge(html_options)
         when :tr
-          content_tag :tr, placeholder, {data: {signed_params: signed_params(model_or_options)}, is: "futurism-table-row"}.merge(html_options)
+          content_tag :tr, placeholder, {data: dataset, is: "futurism-table-row"}.merge(html_options)
         else
-          content_tag :"futurism-element", placeholder, {data: {signed_params: signed_params(model_or_options)}}.merge(html_options)
+          content_tag :"futurism-element", placeholder, {data: dataset}.merge(html_options)
         end
       end
 
       private
 
-      def signed_params(params)
-        Rails.application.message_verifier("futurism").generate(params)
+      def signed_params
+        Rails.application.message_verifier("futurism").generate(options)
       end
     end
   end

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -32,20 +32,37 @@ module Futurism
     end
 
     def render_element(extends:, options:, placeholder:)
-      html_options = options.delete(:html_options) || {}
-      model_or_options = options.delete(:model) || options
-      case extends
-      when :li
-        content_tag :li, placeholder, {data: {signed_params: futurism_signed_params(model_or_options)}, is: "futurism-li"}.merge(html_options)
-      when :tr
-        content_tag :tr, placeholder, {data: {signed_params: futurism_signed_params(model_or_options)}, is: "futurism-table-row"}.merge(html_options)
-      else
-        content_tag :"futurism-element", placeholder, {data: {signed_params: futurism_signed_params(model_or_options)}}.merge(html_options)
-      end
+      Element.new(extends: extends, options: options, placeholder: placeholder).render
     end
 
-    def futurism_signed_params(params)
-      Rails.application.message_verifier("futurism").generate(params)
+    class Element
+      include ActionView::Helpers
+
+      attr_reader :extends, :placeholder, :html_options, :model_or_options
+
+      def initialize(extends:, placeholder:, options:)
+        @extends = extends
+        @placeholder = placeholder
+        @html_options = options.delete(:html_options) || {}
+        @model_or_options = options.delete(:model) || options
+      end
+
+      def render
+        case extends
+        when :li
+          content_tag :li, placeholder, {data: {signed_params: signed_params(model_or_options)}, is: "futurism-li"}.merge(html_options)
+        when :tr
+          content_tag :tr, placeholder, {data: {signed_params: signed_params(model_or_options)}, is: "futurism-table-row"}.merge(html_options)
+        else
+          content_tag :"futurism-element", placeholder, {data: {signed_params: signed_params(model_or_options)}}.merge(html_options)
+        end
+      end
+
+      private
+
+      def signed_params(params)
+        Rails.application.message_verifier("futurism").generate(params)
+      end
     end
   end
 end

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -22,10 +22,11 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     renderer_spy = Spy.on(ApplicationController, :render)
     post = Post.create title: "Lorem"
     fragment = Nokogiri::HTML.fragment(futurize(post, extends: :div) {})
-    signed_params = fragment.children.first["data-signed-params"]
+    signed_params_array = fragment.children.map { |element| element["data-signed-params"] }
+    sgids = fragment.children.map { |element| element["data-sgid"] }
     subscribe
 
-    perform :receive, {"signed_params" => [signed_params]}
+    perform :receive, {"signed_params" => signed_params_array, "sgids" => sgids}
 
     assert renderer_spy.has_been_called_with? post
   end
@@ -35,13 +36,11 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     Post.create title: "Lorem"
     Post.create title: "Ipsum"
     fragment = Nokogiri::HTML.fragment(futurize(Post.all, extends: :div) {})
-    signed_params = fragment.children.first["data-signed-params"]
+    signed_params_array = fragment.children.map { |element| element["data-signed-params"] }
+    sgids = fragment.children.map { |element| element["data-sgid"] }
     subscribe
 
-    perform :receive, {"signed_params" => [signed_params]}
-
-    signed_params = fragment.children.last["data-signed-params"]
-    perform :receive, {"signed_params" => [signed_params]}
+    perform :receive, {"signed_params" => signed_params_array, "sgids" => sgids}
 
     assert renderer_spy.has_been_called_with? Post.first
     assert renderer_spy.has_been_called_with? Post.last

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -9,7 +9,7 @@ class Futurism::HelperTest < ActionView::TestCase
     element = Nokogiri::HTML.fragment(futurize(post, extends: :div, html_options: {class: "absolute inset-0"}) {})
 
     assert_equal "futurism-element", element.children.first.name
-    assert_equal post, GlobalID::Locator.locate_signed(element.children.first["data-sgid"]) 
+    assert_equal post, GlobalID::Locator.locate_signed(element.children.first["data-sgid"])
     assert_equal signed_params({}), element.children.first["data-signed-params"]
     assert_equal "absolute inset-0", element.children.first["class"]
 

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -6,9 +6,13 @@ class Futurism::HelperTest < ActionView::TestCase
   test "renders html options" do
     post = Post.create title: "Lorem"
 
-    assert_dom_equal %(<futurism-element class="absolute inset-0" data-signed-params="#{futurism_signed_params(post)}"></futurism-element>), futurize(post, extends: :div, html_options: {class: "absolute inset-0"}) {}
+    assert_dom_equal %(<futurism-element class="absolute inset-0" data-signed-params="#{signed_params(post)}"></futurism-element>), futurize(post, extends: :div, html_options: {class: "absolute inset-0"}) {}
 
     params = {partial: "posts/card", locals: {post: post}}
-    assert_dom_equal %(<futurism-element class="flex justify-center" data-signed-params="#{futurism_signed_params(**params)}"></futurism-element>), futurize(params.merge({html_options: {class: "flex justify-center"}, extends: :div})) {}
+    assert_dom_equal %(<futurism-element class="flex justify-center" data-signed-params="#{signed_params(**params)}"></futurism-element>), futurize(params.merge({html_options: {class: "flex justify-center"}, extends: :div})) {}
+  end
+
+  def signed_params(params)
+    Rails.application.message_verifier("futurism").generate(params)
   end
 end

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -6,10 +6,20 @@ class Futurism::HelperTest < ActionView::TestCase
   test "renders html options" do
     post = Post.create title: "Lorem"
 
-    assert_dom_equal %(<futurism-element class="absolute inset-0" data-signed-params="#{signed_params(post)}"></futurism-element>), futurize(post, extends: :div, html_options: {class: "absolute inset-0"}) {}
+    element = Nokogiri::HTML.fragment(futurize(post, extends: :div, html_options: {class: "absolute inset-0"}) {})
+
+    assert_equal "futurism-element", element.children.first.name
+    assert_equal post, GlobalID::Locator.locate_signed(element.children.first["data-sgid"]) 
+    assert_equal signed_params({}), element.children.first["data-signed-params"]
+    assert_equal "absolute inset-0", element.children.first["class"]
 
     params = {partial: "posts/card", locals: {post: post}}
-    assert_dom_equal %(<futurism-element class="flex justify-center" data-signed-params="#{signed_params(**params)}"></futurism-element>), futurize(params.merge({html_options: {class: "flex justify-center"}, extends: :div})) {}
+    element = Nokogiri::HTML.fragment(futurize(params.merge({html_options: {class: "flex justify-center"}, extends: :div})) {})
+
+    assert_equal "futurism-element", element.children.first.name
+    assert_nil element.children.first["data-sgid"]
+    assert_equal signed_params(params), element.children.first["data-signed-params"]
+    assert_equal "flex justify-center", element.children.first["class"]
   end
 
   def signed_params(params)


### PR DESCRIPTION
# Refactor

## Description

Clean up the internals a bit, create a wrapper class for a futurism `Element`

