### PR TITLE
34 identify channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ Lazy-load Rails partials via CableReady
 <img src="https://user-images.githubusercontent.com/4352208/88374198-9e6f3500-cd99-11ea-804b-0216ed320eff.jpg" alt="birmingham-museums-trust-GrvC6MI-z4w-unsplash" width="50%" align="center"/>
 <span>Photo by <a href="https://unsplash.com/@birminghammuseumstrust?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Birmingham Museums Trust</a> on <a href="https://unsplash.com/s/photos/futurism?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Unsplash</a></span>
 
+## Table of Contents
+
+- [Table of Contents](#table-of-contents)
+- [Facts](#facts)
+  - [Browser Support](#browser-support)
+- [Usage](#usage)
+- [API](#api)
+  - [Resource](#resource)
+  - [Explicit Partial](#explicit-partial)
+  - [HTML Options](#html-options)
+- [Events](#events)
+- [Installation](#installation)
+  - [Manual Installation](#manual-installation)
+- [Authentication](#authentication)
+- [Contributing](#contributing)
+- [License](#license)
+- [Contributors](#contributors)
+
 ## Facts
 - only one dependency: CableReady
 - bundle size (without CableReady) is around [~1.04kB](https://bundlephobia.com/result?p=@minthesize/futurism@0.1.3)
@@ -162,6 +180,23 @@ import consumer from './consumer'
 Futurism.initializeElements()
 Futurism.createSubscription(consumer)
 ```
+
+## Authentication
+For authentication, you can rely on ActionCable identifiers, for example, if you use Devise:
+
+```ruby
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = env["warden"].user || reject_unauthorized_connection
+    end
+  end
+end
+```
+
+The [Stimulus Reflex Docs](https://docs.stimulusreflex.com/authentication) have an excellent section about all sorts of authentication.
 
 ## Contributing
 

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -7,15 +7,15 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   include CableReady::Broadcaster
 
   setup do
-    stub_connection(env: {"SCRIPT_NAME" => "/cable"})
+    stub_connection(env: {"SCRIPT_NAME" => "/cable"}, identifiers: [:current_user], current_user: Struct.new(:id)[1])
   end
 
   test "subscribed" do
-    subscribe
+    subscribe(channel: "Futurism::Channel")
 
     assert subscription.confirmed?
 
-    assert_has_stream "Futurism::Channel"
+    assert_has_stream "Futurism::Channel:1"
   end
 
   test "broadcasts a rendered model after receiving signed params" do
@@ -119,9 +119,9 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   test "broadcasts an inline rendered text" do
     fragment = Nokogiri::HTML.fragment(futurize(inline: "<%= 1 + 2 %>", extends: :div) {})
     signed_params = fragment.children.first["data-signed-params"]
-    subscribe
+    subscribe(channel: "Futurism::Channel")
 
-    assert_broadcast_on("Futurism::Channel", "cableReady" => true, "operations" => {"outerHtml" => [{"selector" => "[data-signed-params='#{signed_params}']", "html" => "3"}]}) do
+    assert_broadcast_on("Futurism::Channel:1", "cableReady" => true, "operations" => {"outerHtml" => [{"selector" => "[data-signed-params='#{signed_params}']", "html" => "3"}]}) do
       perform :receive, {"signed_params" => [signed_params]}
     end
   end
@@ -130,9 +130,9 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     post = Post.create title: "Lorem"
     fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}, extends: :div) {})
     signed_params = fragment.children.first["data-signed-params"]
-    subscribe
+    subscribe(channel: "Futurism::Channel")
 
-    assert_broadcast_on("Futurism::Channel", "cableReady" => true, "operations" => {"outerHtml" => [{"selector" => "[data-signed-params='#{signed_params}']", "html" => "<div class=\"card\">\n  Lorem\n  <a href=\"/posts/1/edit\">Edit</a>\n</div>\n"}]}) do
+    assert_broadcast_on("Futurism::Channel:1", "cableReady" => true, "operations" => {"outerHtml" => [{"selector" => "[data-signed-params='#{signed_params}']", "html" => "<div class=\"card\">\n  Lorem\n  <a href=\"/posts/1/edit\">Edit</a>\n</div>\n"}]}) do
       perform :receive, {"signed_params" => [signed_params]}
     end
   end


### PR DESCRIPTION
# Enhancement

## Description

This PR adds ActionCable identifiers.

Fixes #34

## Why should this be added

This should prevent any users seeing updates from other users and relies on `identified_by` in `ApplicationCable::Connection`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
