### PR TITLE
Add data attributes from html options

### DIFF
--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -36,31 +36,32 @@ module Futurism
     class Element
       include ActionView::Helpers
 
-      attr_reader :extends, :placeholder, :html_options, :model, :options
+      attr_reader :extends, :placeholder, :html_options, :data_attributes, :model, :options
 
       def initialize(extends:, placeholder:, options:)
         @extends = extends
         @placeholder = placeholder
         @html_options = options.delete(:html_options) || {}
+        @data_attributes = html_options.fetch(:data, {}).except(:sgid, :signed_params)
         @model = options.delete(:model)
-        @options = options
+        @options = data_attributes.any? ? options.merge(data: data_attributes) : options
       end
 
       def dataset
-        {
+        data_attributes.merge({
           signed_params: signed_params,
           sgid: model && model.to_sgid.to_s
-        }
+        })
       end
 
       def render
         case extends
         when :li
-          content_tag :li, placeholder, {data: dataset, is: "futurism-li"}.merge(html_options)
+          content_tag :li, placeholder, html_options.deep_merge({data: dataset, is: "futurism-li"})
         when :tr
-          content_tag :tr, placeholder, {data: dataset, is: "futurism-table-row"}.merge(html_options)
+          content_tag :tr, placeholder, html_options.deep_merge({data: dataset, is: "futurism-table-row"})
         else
-          content_tag :"futurism-element", placeholder, {data: dataset}.merge(html_options)
+          content_tag :"futurism-element", placeholder, html_options.deep_merge({data: dataset})
         end
       end
 

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -22,6 +22,17 @@ class Futurism::HelperTest < ActionView::TestCase
     assert_equal "flex justify-center", element.children.first["class"]
   end
 
+  test "ensures signed_params and sgid are not overwritable" do
+    post = Post.create title: "Lorem"
+
+    element = Nokogiri::HTML.fragment(futurize(post, extends: :div, html_options: {data: {controller: "test", sgid: "test", signed_params: "test"}}) {})
+
+    assert_equal post, GlobalID::Locator.locate_signed(element.children.first["data-sgid"])
+    assert_equal signed_params({data: {controller: "test"}}), element.children.first["data-signed-params"]
+  end
+
+
+
   def signed_params(params)
     Rails.application.message_verifier("futurism").generate(params)
   end

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -31,8 +31,6 @@ class Futurism::HelperTest < ActionView::TestCase
     assert_equal signed_params({data: {controller: "test"}}), element.children.first["data-signed-params"]
   end
 
-
-
   def signed_params(params)
     Rails.application.message_verifier("futurism").generate(params)
   end


### PR DESCRIPTION
# Type of PR - enhancement

## Description
* Allow data attributes to be passed in html_options, without removing `sgid`, `signed_params`
* Disallow overwriting `sgid`, `signed_params` data-attributes

Fixes https://github.com/julianrubisch/futurism/issues/43

## Why should this be added

Allows Futurism to respect developers wishes to pass in data-attributes e.g. Stimulus controllers

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
