### PR TITLE
42 eager loading

### DIFF
--- a/javascript/elements/futurism_element.js
+++ b/javascript/elements/futurism_element.js
@@ -1,9 +1,13 @@
 /* global HTMLElement */
 
-import { extendElementWithIntersectionObserver } from './futurism_utils'
+import {
+  extendElementWithIntersectionObserver,
+  extendElementWithEagerLoading
+} from './futurism_utils'
 
 export default class FuturismElement extends HTMLElement {
   connectedCallback () {
     extendElementWithIntersectionObserver(this)
+    extendElementWithEagerLoading(this)
   }
 }

--- a/javascript/elements/futurism_li.js
+++ b/javascript/elements/futurism_li.js
@@ -1,9 +1,13 @@
 /* global HTMLLIElement */
 
-import { extendElementWithIntersectionObserver } from './futurism_utils'
+import {
+  extendElementWithIntersectionObserver,
+  extendElementWithEagerLoading
+} from './futurism_utils'
 
 export default class FuturismLI extends HTMLLIElement {
   connectedCallback () {
     extendElementWithIntersectionObserver(this)
+    extendElementWithEagerLoading(this)
   }
 }

--- a/javascript/elements/futurism_table_row.js
+++ b/javascript/elements/futurism_table_row.js
@@ -1,9 +1,13 @@
 /* global HTMLTableRowElement */
 
-import { extendElementWithIntersectionObserver } from './futurism_utils'
+import {
+  extendElementWithIntersectionObserver,
+  extendElementWithEagerLoading
+} from './futurism_utils'
 
 export default class FuturismTableRow extends HTMLTableRowElement {
   connectedCallback () {
     extendElementWithIntersectionObserver(this)
+    extendElementWithEagerLoading(this)
   }
 }

--- a/javascript/elements/futurism_utils.js
+++ b/javascript/elements/futurism_utils.js
@@ -1,20 +1,22 @@
 /* global IntersectionObserver, CustomEvent, setTimeout */
 
-const dispatchAppearEvent = (entry, observer) => {
+const dispatchAppearEvent = (entry, observer = null) => {
   if (!window.Futurism) {
     setTimeout(() => dispatchAppearEvent(entry, observer), 1)
     return
   }
 
+  const target = entry.target ? entry.target : entry
+
   const evt = new CustomEvent('futurism:appear', {
     bubbles: true,
     detail: {
-      target: entry.target,
+      target,
       observer
     }
   })
 
-  entry.target.dispatchEvent(evt)
+  target.dispatchEvent(evt)
 }
 
 const observerCallback = (entries, observer) => {
@@ -30,4 +32,11 @@ export const extendElementWithIntersectionObserver = element => {
   })
 
   element.observer.observe(element)
+}
+
+export const extendElementWithEagerLoading = element => {
+  if (element.dataset['eager'] === 'true') {
+    element.observer.disconnect()
+    dispatchAppearEvent(element)
+  }
 }

--- a/javascript/elements/futurism_utils.js
+++ b/javascript/elements/futurism_utils.js
@@ -35,7 +35,7 @@ export const extendElementWithIntersectionObserver = element => {
 }
 
 export const extendElementWithEagerLoading = element => {
-  if (element.dataset['eager'] === 'true') {
+  if (element.dataset.eager === 'true') {
     if (element.observer) element.observer.disconnect()
     dispatchAppearEvent(element)
   }

--- a/javascript/elements/futurism_utils.js
+++ b/javascript/elements/futurism_utils.js
@@ -36,7 +36,7 @@ export const extendElementWithIntersectionObserver = element => {
 
 export const extendElementWithEagerLoading = element => {
   if (element.dataset['eager'] === 'true') {
-    element.observer.disconnect()
+    if (element.observer) element.observer.disconnect()
     dispatchAppearEvent(element)
   }
 }

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -36,11 +36,12 @@ module Futurism
     class Element
       include ActionView::Helpers
 
-      attr_reader :extends, :placeholder, :html_options, :data_attributes, :model, :options
+      attr_reader :extends, :placeholder, :html_options, :data_attributes, :model, :options, :eager
 
       def initialize(extends:, placeholder:, options:)
         @extends = extends
         @placeholder = placeholder
+        @eager = options.delete(:eager)
         @html_options = options.delete(:html_options) || {}
         @data_attributes = html_options.fetch(:data, {}).except(:sgid, :signed_params)
         @model = options.delete(:model)
@@ -50,7 +51,8 @@ module Futurism
       def dataset
         data_attributes.merge({
           signed_params: signed_params,
-          sgid: model && model.to_sgid.to_s
+          sgid: model && model.to_sgid.to_s,
+          eager: eager.presence
         })
       end
 

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -11,6 +11,7 @@ class Futurism::HelperTest < ActionView::TestCase
     assert_equal "futurism-element", element.children.first.name
     assert_equal post, GlobalID::Locator.locate_signed(element.children.first["data-sgid"])
     assert_equal signed_params({data: {controller: "test"}}), element.children.first["data-signed-params"]
+    assert_nil element.children.first["data-eager"]
     assert_equal "absolute inset-0", element.children.first["class"]
 
     params = {partial: "posts/card", locals: {post: post}}
@@ -18,6 +19,7 @@ class Futurism::HelperTest < ActionView::TestCase
 
     assert_equal "futurism-element", element.children.first.name
     assert_nil element.children.first["data-sgid"]
+    assert_nil element.children.first["data-eager"]
     assert_equal signed_params(params.merge({data: {action: "test#click"}})), element.children.first["data-signed-params"]
     assert_equal "flex justify-center", element.children.first["class"]
   end
@@ -37,6 +39,17 @@ class Futurism::HelperTest < ActionView::TestCase
     element = Nokogiri::HTML.fragment(futurize("posts/form", post: post, extends: :div) {})
 
     assert resource(signed_params: element.children.first["data-signed-params"], sgid: nil)[:locals][:post].new_record?
+  end
+
+  test "renders an eager loading data attribute" do
+    post = Post.create title: "Lorem"
+
+    element = Nokogiri::HTML.fragment(futurize(post, extends: :div, eager: true) {})
+
+    assert_equal "true", element.children.first["data-eager"]
+
+    element = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}, eager: true, extends: :div) {})
+    assert_equal "true", element.children.first["data-eager"]
   end
 
   def signed_params(params)


### PR DESCRIPTION
# Enhancement

## Description

Allow eager loading of invisible content, e.g. for tabs.

This PR adds an `eager: true` option you can specify in your `futurize` call that will render a `data-eager="true"` attribute on `<futurism-element>`.

If this attribute is present, the JS will disconnect any present `IntersectionObserver` and straight away call the `futurism:appear` event.

Fixes #42

## Why should this be added

While it may seem counterintuitive at first, this is actually a good idea if you have invisible content that you still want to skip in your initially rendered HTML, e.g. hidden forms or tabs.

It might still lead to increased bandwidth usage, so use sparingly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
