### PR TITLE
Reset before turbolinks caching

### DIFF
--- a/javascript/elements/futurism_utils.js
+++ b/javascript/elements/futurism_utils.js
@@ -31,7 +31,9 @@ export const extendElementWithIntersectionObserver = element => {
     observer: new IntersectionObserver(observerCallback.bind(element), {})
   })
 
-  element.observer.observe(element)
+  if (!element.hasAttribute('keep')) {
+    element.observer.observe(element)
+  }
 }
 
 export const extendElementWithEagerLoading = element => {

--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -36,9 +36,24 @@ const defineElements = e => {
   }
 }
 
+const cleanUp = e => {
+  document.querySelector('.count').innerHTML = 'test'
+  Object.entries(sessionStorage).forEach(([key, payload]) => {
+    const targetElement = document.querySelector(
+      `[data-futurism-hash="${key}"]`
+    )
+
+    if (targetElement) {
+      targetElement.outerHTML = payload
+      sessionStorage.removeItem(key)
+    }
+  })
+}
+
 export const initializeElements = () => {
   document.addEventListener('DOMContentLoaded', defineElements)
   document.addEventListener('turbolinks:load', defineElements)
+  document.addEventListener('turbolinks:before-cache', cleanUp)
   document.addEventListener('cable-ready:after-outer-html', e => {
     sha256(e.detail.element.outerHTML).then(hashedContent => {
       sessionStorage.setItem(hashedContent, e.detail.element.outerHTML)

--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -56,6 +56,7 @@ export const initializeElements = () => {
   document.addEventListener('turbolinks:before-cache', cleanUp)
   document.addEventListener('cable-ready:after-outer-html', e => {
     sha256(e.detail.element.outerHTML).then(hashedContent => {
+      e.detail.element.setAttribute('keep', '')
       sessionStorage.setItem(hashedContent, e.detail.element.outerHTML)
       e.target.dataset.futurismHash = hashedContent
     })

--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -1,4 +1,4 @@
-/* global customElements */
+/* global customElements, sessionStorage */
 
 import FuturismElement from './futurism_element'
 import FuturismTableRow from './futurism_table_row'

--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -37,7 +37,6 @@ const defineElements = e => {
 }
 
 const cleanUp = e => {
-  document.querySelector('.count').innerHTML = 'test'
   Object.entries(sessionStorage).forEach(([key, payload]) => {
     const targetElement = document.querySelector(
       `[data-futurism-hash="${key}"]`

--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -36,7 +36,15 @@ const defineElements = e => {
   }
 }
 
-const cleanUp = e => {
+const cachePlaceholders = e => {
+  sha256(e.detail.element.outerHTML).then(hashedContent => {
+    e.detail.element.setAttribute('keep', '')
+    sessionStorage.setItem(hashedContent, e.detail.element.outerHTML)
+    e.target.dataset.futurismHash = hashedContent
+  })
+}
+
+const restorePlaceholders = e => {
   Object.entries(sessionStorage).forEach(([key, payload]) => {
     const targetElement = document.querySelector(
       `[data-futurism-hash="${key}"]`
@@ -52,14 +60,8 @@ const cleanUp = e => {
 export const initializeElements = () => {
   document.addEventListener('DOMContentLoaded', defineElements)
   document.addEventListener('turbolinks:load', defineElements)
-  document.addEventListener('turbolinks:before-cache', cleanUp)
-  document.addEventListener('cable-ready:after-outer-html', e => {
-    sha256(e.detail.element.outerHTML).then(hashedContent => {
-      e.detail.element.setAttribute('keep', '')
-      sessionStorage.setItem(hashedContent, e.detail.element.outerHTML)
-      e.target.dataset.futurismHash = hashedContent
-    })
-  })
+  document.addEventListener('turbolinks:before-cache', restorePlaceholders)
+  document.addEventListener('cable-ready:after-outer-html', cachePlaceholders)
 
   polyfillCustomElements()
 }

--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -39,22 +39,29 @@ const defineElements = e => {
 const cachePlaceholders = e => {
   sha256(e.detail.element.outerHTML).then(hashedContent => {
     e.detail.element.setAttribute('keep', '')
-    sessionStorage.setItem(hashedContent, e.detail.element.outerHTML)
+    sessionStorage.setItem(
+      `futurism-${hashedContent}`,
+      e.detail.element.outerHTML
+    )
     e.target.dataset.futurismHash = hashedContent
   })
 }
 
 const restorePlaceholders = e => {
-  Object.entries(sessionStorage).forEach(([key, payload]) => {
-    const targetElement = document.querySelector(
-      `[data-futurism-hash="${key}"]`
-    )
+  const inNamespace = ([key, _payload]) => key.startsWith('futurism-')
+  Object.entries(sessionStorage)
+    .filter(inNamespace)
+    .forEach(([key, payload]) => {
+      const match = /^futurism-(.*)/.exec(key)
+      const targetElement = document.querySelector(
+        `[data-futurism-hash="${match[1]}"]`
+      )
 
-    if (targetElement) {
-      targetElement.outerHTML = payload
-      sessionStorage.removeItem(key)
-    }
-  })
+      if (targetElement) {
+        targetElement.outerHTML = payload
+        sessionStorage.removeItem(key)
+      }
+    })
 }
 
 export const initializeElements = () => {

--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -4,6 +4,8 @@ import FuturismElement from './futurism_element'
 import FuturismTableRow from './futurism_table_row'
 import FuturismLI from './futurism_li'
 
+import { sha256 } from '../utils/crypto'
+
 const polyfillCustomElements = () => {
   if (customElements) {
     try {
@@ -37,6 +39,12 @@ const defineElements = e => {
 export const initializeElements = () => {
   document.addEventListener('DOMContentLoaded', defineElements)
   document.addEventListener('turbolinks:load', defineElements)
+  document.addEventListener('cable-ready:after-outer-html', e => {
+    sha256(e.detail.element.outerHTML).then(hashedContent => {
+      sessionStorage.setItem(hashedContent, e.detail.element.outerHTML)
+      e.target.dataset.futurismHash = hashedContent
+    })
+  })
 
   polyfillCustomElements()
 }

--- a/javascript/utils/crypto.js
+++ b/javascript/utils/crypto.js
@@ -1,0 +1,15 @@
+export async function sha256 (message) {
+  // encode as UTF-8
+  const msgBuffer = new TextEncoder('utf-8').encode(message)
+
+  // hash the message
+  const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer)
+
+  // convert ArrayBuffer to Array
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+
+  // convert bytes to hex string
+  const hashHex = hashArray.map(b => ('00' + b.toString(16)).slice(-2)).join('')
+
+  return hashHex
+}

--- a/javascript/utils/crypto.js
+++ b/javascript/utils/crypto.js
@@ -1,3 +1,5 @@
+/* global crypto */
+
 export async function sha256 (message) {
   // encode as UTF-8
   const msgBuffer = new TextEncoder('utf-8').encode(message)


### PR DESCRIPTION
# Bug fix

## Description

This PR addresses the "flash of manipulated content" that occurs if you do a Turbolinks restoration visit (you navigate back, see a flash of the cached - rendered - content before the placeholders appear again and the page is fetched and reloaded).

Not only is this confusing to the user, it can also serve stale content which then gets updated again when the server fetch succeeds. A better strategy is to re-render the placeholders before Turbolinks caching starts.

To achieve that, I resorted to `sessionStorage` (it seemed a better fit than `localStorage` because it clears automatically when a user quits the session) to save the placeholder elements under a key that represents the `outerHTML` as a SHA256 hash.

That same hash is stored as a `data-futurism-hash` attribute on the rendered element, to be able to restore the placeholder on `turbolinks:before-cache` (and remove the item from `sessionStorage`).

A last obstacle was to _bypass_ the `IntersectionObserver` in the before-cache version of the DOM, because even in a short moment of being visible it would trigger, thus again flashing. I solved this by adding a `keep` attribute (naming is hard, I couldn't come up with anything better) to the `<futurism-element>` before writing it to the `sessionStorage` and using it to bypass the start of the observation. I think this approach is solid, but I might be wrong.

Fixes #23 


## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
