### PR TITLE
Add skip_in_test flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Lazy-load Rails partials via CableReady
 - [Installation](#installation)
   - [Manual Installation](#manual-installation)
 - [Authentication](#authentication)
+- [Testing](#testing)
 - [Gotchas](#gotchas)
 - [Contributing](#contributing)
 - [License](#license)
@@ -212,6 +213,15 @@ end
 ```
 
 The [Stimulus Reflex Docs](https://docs.stimulusreflex.com/authentication) have an excellent section about all sorts of authentication.
+
+## Testing
+In Rails system tests there is a chance that flaky errors will occur due to Capybara not waiting for the placeholder elements to be replaced. To overcome this, add the flag
+
+```ruby
+Futurism.skip_in_test = true
+```
+
+to an initializer, for example `config/initializers/futurism.rb`.
 
 ## Gotchas
 

--- a/lib/futurism.rb
+++ b/lib/futurism.rb
@@ -10,6 +10,8 @@ module Futurism
 
   autoload :Helpers, "futurism/helpers"
 
+  mattr_accessor :skip_in_test
+
   ActiveSupport.on_load(:action_view) {
     include Futurism::Helpers
   }

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -1,6 +1,15 @@
 module Futurism
   module Helpers
     def futurize(records_or_string = nil, extends:, **options, &block)
+      if Rails.env.test? && Futurism.skip_in_test
+        if records_or_string.nil?
+          render options
+        else
+          render records_or_string, options
+        end
+        return
+      end
+
       placeholder = capture(&block)
 
       if records_or_string.is_a?(ActiveRecord::Base) || records_or_string.is_a?(ActiveRecord::Relation)


### PR DESCRIPTION
# Enhancement

This adds a `Futurism.skip_in_test` configuration flag, so lazy loading can be skipped in Rails system tests etc.

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
