### PR TITLE
Pass url on each request and parse to build params hash

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    spy (1.0.0)
     sqlite3 (1.4.2)
     standard (0.7)
       rubocop (= 0.92)
@@ -183,7 +182,6 @@ DEPENDENCIES
   nokogiri
   pry (~> 0.12.2)
   rake (~> 13.0)
-  spy
   sqlite3
   standardrb
 

--- a/futurism.gemspec
+++ b/futurism.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "nokogiri"
   spec.add_development_dependency "standardrb"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "spy"
 
   spec.add_dependency "rack", "~> 2.0"
   spec.add_dependency "rails", ">= 5.2"

--- a/javascript/futurism_channel.js
+++ b/javascript/futurism_channel.js
@@ -18,7 +18,7 @@ const debounceEvents = (callback, delay = 20) => {
 
 export const createSubscription = consumer => {
   consumer.subscriptions.create('Futurism::Channel', {
-    connected () {
+    connected() {
       window.Futurism = this
       document.addEventListener(
         'futurism:appear',
@@ -26,13 +26,14 @@ export const createSubscription = consumer => {
           this.send({
             signed_params: events.map(e => e.target.dataset.signedParams),
             sgids: events.map(e => e.target.dataset.sgid),
-            signed_controllers: events.map(e => e.target.dataset.signedController)
+            signed_controllers: events.map(e => e.target.dataset.signedController),
+            urls: events.map(_ => window.location.href)
           })
         })
       )
     },
 
-    received (data) {
+    received(data) {
       if (data.cableReady) {
         CableReady.perform(data.operations, {
           emitMissingElementWarnings: false

--- a/lib/futurism.rb
+++ b/lib/futurism.rb
@@ -3,6 +3,8 @@ require "action_cable"
 require "cable_ready"
 require "futurism/engine"
 require "futurism/message_verifier"
+require "futurism/resolver/controller"
+require "futurism/resolver/controller/renderer"
 require "futurism/channel"
 require "futurism/helpers"
 

--- a/lib/futurism/message_verifier.rb
+++ b/lib/futurism/message_verifier.rb
@@ -1,6 +1,8 @@
 module Futurism
   module MessageVerifier
-    private
+    def self.message_verifier
+      @message_verifier ||= Rails.application.message_verifier("futurism")
+    end
 
     def message_verifier
       @message_verifier ||= Rails.application.message_verifier("futurism")

--- a/lib/futurism/resolver/controller.rb
+++ b/lib/futurism/resolver/controller.rb
@@ -1,0 +1,21 @@
+module Futurism
+  module Resolver
+    class Controller
+      def self.from(signed_string:)
+        if signed_string.present?
+          Futurism::MessageVerifier
+            .message_verifier
+            .verify(signed_string)
+            .to_s
+            .safe_constantize
+        else
+          default_controller
+        end
+      end
+
+      def self.default_controller
+        Futurism.default_controller || ::ApplicationController
+      end
+    end
+  end
+end

--- a/lib/futurism/resolver/controller/renderer.rb
+++ b/lib/futurism/resolver/controller/renderer.rb
@@ -30,6 +30,8 @@ module Futurism
             path = ActionDispatch::Journey::Router::Utils.normalize_path(uri.path)
             query_hash = Rack::Utils.parse_nested_query(uri.query)
 
+            path_params = Rails.application.routes.recognize_path(path)
+
             self.renderer =
               renderer.new(
                 "rack.request.query_hash" => query_hash,
@@ -40,7 +42,7 @@ module Futurism
                 Rack::PATH_INFO => path,
                 Rack::REQUEST_PATH => path,
                 Rack::QUERY_STRING => uri.query,
-                ActionDispatch::Http::Parameters::PARAMETERS_KEY => params.merge(query_hash)
+                ActionDispatch::Http::Parameters::PARAMETERS_KEY => params.symbolize_keys.merge(path_params).merge(query_hash)
               )
           end
 

--- a/lib/futurism/resolver/controller/renderer.rb
+++ b/lib/futurism/resolver/controller/renderer.rb
@@ -1,0 +1,55 @@
+module Futurism
+  module Resolver
+    class Controller
+      class Renderer
+        def self.for(controller:, connection:, url:, params:)
+          new(controller: controller, connection: connection, url: url, params: params).renderer
+        end
+
+        def initialize(controller:, connection:, url:, params:)
+          @controller = controller
+          @connection = connection
+          @url = url || ""
+          @params = params || {}
+
+          setup_env!
+        end
+
+        def renderer
+          @renderer ||= controller.renderer
+        end
+
+        private
+
+        attr_reader :controller, :connection, :url, :params
+        attr_writer :renderer
+
+        def setup_env!
+          if url.present?
+            uri = URI.parse(url)
+            path = ActionDispatch::Journey::Router::Utils.normalize_path(uri.path)
+            query_hash = Rack::Utils.parse_nested_query(uri.query)
+
+            self.renderer =
+              renderer.new(
+                "rack.request.query_hash" => query_hash,
+                "rack.request.query_string" => uri.query,
+                "ORIGINAL_SCRIPT_NAME" => "",
+                "ORIGINAL_FULLPATH" => path,
+                Rack::SCRIPT_NAME => "",
+                Rack::PATH_INFO => path,
+                Rack::REQUEST_PATH => path,
+                Rack::QUERY_STRING => uri.query,
+                ActionDispatch::Http::Parameters::PARAMETERS_KEY => params.merge(query_hash)
+              )
+          end
+
+          # Copy connection env to renderer to fix some RACK related issues from gems like
+          # Warden or Devise
+          new_env = connection.env.merge(renderer.instance_variable_get(:@env))
+          renderer.instance_variable_set(:@env, new_env)
+        end
+      end
+    end
+  end
+end

--- a/test/dummy/app/controllers/home_controller.rb
+++ b/test/dummy/app/controllers/home_controller.rb
@@ -1,0 +1,6 @@
+class HomeController < ApplicationController
+  # GET /home
+  def index
+    head :no_content
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   resources :posts
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  root "home#index"
 end

--- a/test/resolver/controller/renderer_test.rb
+++ b/test/resolver/controller/renderer_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class DummyController < ActionController::Base
+  def name_helper
+    "FUTURISM".freeze
+  end
+  helper_method :name_helper
+
+  def controller_and_action_helper
+    [params["controller"], params["action"]].join(":")
+  end
+  helper_method :controller_and_action_helper
+
+  def name_from_params_helper
+    params["name"]
+  end
+  helper_method :name_from_params_helper
+end
+
+def dummy_connection
+  connection = Minitest::Mock.new
+  connection.expect(:env, {"HTTP_VAR" => "HTTP_VAR_VALUE"})
+  connection
+end
+
+class Futurism::Resolver::Controller::RendererTest < ActiveSupport::TestCase
+  test ".for controller configures renderer" do
+    renderer = Futurism::Resolver::Controller::Renderer.for(controller: ApplicationController,
+                                                            connection: dummy_connection,
+                                                            url: "http://www.example.org?someParam=1234",
+                                                            params: {"SOME" => "SOME_VALUE"})
+    assert_equal renderer.controller, ApplicationController
+
+    assert_equal renderer.render(inline: "<%= request.env['HTTP_VAR'] %>"), "HTTP_VAR_VALUE"
+    assert_equal renderer.render(inline: "<%= params['someParam'] %>"), "1234"
+    assert_equal renderer.render(inline: "<%= params['SOME'] %>"), "SOME_VALUE"
+  end
+
+  test ".for controller configures renderer using the passed in controller" do
+    renderer = Futurism::Resolver::Controller::Renderer.for(controller: DummyController,
+                                                            connection: dummy_connection,
+                                                            url: "http://www.example.org?someParam=1234",
+                                                            params: {"SOME" => "SOME_VALUE"})
+    assert_equal renderer.controller, DummyController
+
+    assert_equal renderer.render(inline: "<%= request.env['HTTP_VAR'] %>"), "HTTP_VAR_VALUE"
+    assert_equal renderer.render(inline: "<%= params['someParam'] %>"), "1234"
+    assert_equal renderer.render(inline: "<%= params['SOME'] %>"), "SOME_VALUE"
+  end
+
+  test "renderer.render resolves helper methods" do
+    renderer = Futurism::Resolver::Controller::Renderer.for(controller: DummyController,
+                                                            connection: dummy_connection,
+                                                            url: "http://www.example.org?name=the%20future",
+                                                            params: {})
+
+    rendered_html = renderer.render(inline: "Hi <%= name_helper %>")
+
+    assert_equal rendered_html, "Hi FUTURISM"
+  end
+
+  test "renderer.render resolves helper methods that rely on params from controller" do
+    renderer = Futurism::Resolver::Controller::Renderer.for(controller: DummyController,
+                                                            connection: dummy_connection,
+                                                            url: "http://www.example.org?name=the%20future!",
+                                                            params: {"controller" => "home", "action" => "index"})
+
+    rendered_html = renderer.render(inline: "Hi <%= controller_and_action_helper %>")
+
+    assert_equal rendered_html, "Hi home:index"
+  end
+
+  test "renderer.render resolves helper methods that rely on params from url" do
+    renderer = Futurism::Resolver::Controller::Renderer.for(controller: DummyController,
+                                                            connection: dummy_connection,
+                                                            url: "http://www.example.org?name=the%20future!",
+                                                            params: {})
+    rendered_html = renderer.render(inline: "Hi <%= name_from_params_helper %>")
+
+    assert_equal rendered_html, "Hi the future!"
+  end
+end

--- a/test/resolver/controller/renderer_test.rb
+++ b/test/resolver/controller/renderer_test.rb
@@ -65,7 +65,7 @@ class Futurism::Resolver::Controller::RendererTest < ActiveSupport::TestCase
     renderer = Futurism::Resolver::Controller::Renderer.for(controller: DummyController,
                                                             connection: dummy_connection,
                                                             url: "http://www.example.org?name=the%20future!",
-                                                            params: {"controller" => "home", "action" => "index"})
+                                                            params: {})
 
     rendered_html = renderer.render(inline: "Hi <%= controller_and_action_helper %>")
 
@@ -92,6 +92,6 @@ class Futurism::Resolver::Controller::RendererTest < ActiveSupport::TestCase
 
     rendered_html = renderer.render(inline: "<%= link_to post_path(id: #{post.id}) %>")
 
-    assert_equal rendered_html, "<a href=\"/posts/1\">Lorem</a>"
+    assert_equal rendered_html, "<a href=\"/\">/posts/1</a>"
   end
 end

--- a/test/resolver/controller/renderer_test.rb
+++ b/test/resolver/controller/renderer_test.rb
@@ -24,6 +24,8 @@ def dummy_connection
 end
 
 class Futurism::Resolver::Controller::RendererTest < ActiveSupport::TestCase
+  include Rails.application.routes.url_helpers
+
   test ".for controller configures renderer" do
     renderer = Futurism::Resolver::Controller::Renderer.for(controller: ApplicationController,
                                                             connection: dummy_connection,
@@ -78,5 +80,18 @@ class Futurism::Resolver::Controller::RendererTest < ActiveSupport::TestCase
     rendered_html = renderer.render(inline: "Hi <%= name_from_params_helper %>")
 
     assert_equal rendered_html, "Hi the future!"
+  end
+
+  test "renderer.render renders partials that contain a link_to helper" do
+    post = Post.create(title: "Lorem")
+
+    renderer = Futurism::Resolver::Controller::Renderer.for(controller: ApplicationController,
+                                                            connection: dummy_connection,
+                                                            url: "http://www.example.org",
+                                                            params: {})
+
+    rendered_html = renderer.render(inline: "<%= link_to post_path(id: #{post.id}) %>")
+
+    assert_equal rendered_html, "<a href=\"/posts/1\">Lorem</a>"
   end
 end

--- a/test/resolver/controller_test.rb
+++ b/test/resolver/controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class DummyController < ActionController::Base; end
+
+class Futurism::Resolver::ControllerTest < ActiveSupport::TestCase
+  test ".from defaults to ApplicationController" do
+    controller = Futurism::Resolver::Controller.from(signed_string: nil)
+    assert_equal controller, ApplicationController
+  end
+
+  test ".from uses Futurism.default_controller" do
+    Futurism.default_controller = DummyController
+    controller = Futurism::Resolver::Controller.from(signed_string: nil)
+
+    assert_equal controller, DummyController
+
+    Futurism.default_controller = nil
+  end
+
+  test ".from lookups up controller via signed_string:" do
+    signed_controller_string = Futurism::MessageVerifier.message_verifier.generate(DummyController.to_s)
+    controller = Futurism::Resolver::Controller.from(signed_string: signed_controller_string)
+
+    assert_equal controller, DummyController
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,9 +3,9 @@ ENV["RAILS_ENV"] = "test"
 
 require_relative "../test/dummy/config/environment"
 require "rails/test_help"
+require "minitest/mock"
 require "nokogiri"
 require "pry"
-require "spy/integration"
 
 # Filter out the backtrace from minitest while preserving the one from other libraries.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new


### PR DESCRIPTION
# Enhancement

## Description

This PR sends the current url (`window.location.href`) down the wire on each request. This URL is then parsed and the context for the query parameters is passed to the appropriate controller. Specifically, this will allow `params` to be used inside of helper methods or view templates properly

Fixes #54 

Note: this changes up the test suite for channel tests quite a bit and restructures how and where controllers and their renders are resolved. This is to primarily simplify the object's roles and to make testing much easier.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing


