### PR TITLE
Lazily load default controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ You can also pass in the controller that will be used to render the partial.
 By default (i.e. not passing in a value), futurize will use `ApplicationController`, but you may override by setting the Futurism default controller in an initializer, for example `config/initializers/futurism.rb`.
 
 ```ruby
-Futurism.default_controller = MyController
+Futurism.default_controller = "MyController" # to avoid the controller from trying to autoload at boot, provide as a string
 ```
 
 ### HTML Options

--- a/lib/futurism.rb
+++ b/lib/futurism.rb
@@ -13,7 +13,12 @@ module Futurism
 
   autoload :Helpers, "futurism/helpers"
 
-  mattr_accessor :skip_in_test, :default_controller
+  mattr_accessor :skip_in_test, default: false
+
+  mattr_writer :default_controller
+  def self.default_controller
+    (@@default_controller || "::ApplicationController").to_s.constantize
+  end
 
   ActiveSupport.on_load(:action_view) {
     include Futurism::Helpers

--- a/lib/futurism/resolver/controller.rb
+++ b/lib/futurism/resolver/controller.rb
@@ -9,12 +9,8 @@ module Futurism
             .to_s
             .safe_constantize
         else
-          default_controller
+          Futurism.default_controller
         end
-      end
-
-      def self.default_controller
-        Futurism.default_controller || ::ApplicationController
       end
     end
   end

--- a/test/futurism_test.rb
+++ b/test/futurism_test.rb
@@ -1,7 +1,28 @@
 require "test_helper"
 
+class DummyController < ActionController::Base; end
+
 class Futurism::Test < ActiveSupport::TestCase
-  test "truth" do
+  test "module" do
     assert_kind_of Module, Futurism
+  end
+
+  test ".skip_in_test" do
+    assert_equal false, Futurism.skip_in_test
+  end
+
+  test ".default_controller" do
+    assert_equal ApplicationController, Futurism.default_controller
+
+    Futurism.default_controller = nil
+    assert_equal ApplicationController, Futurism.default_controller
+
+    Futurism.default_controller = DummyController
+    assert_equal DummyController, Futurism.default_controller
+
+    Futurism.default_controller = "DummyController"
+    assert_equal DummyController, Futurism.default_controller
+
+    Futurism.default_controller = nil
   end
 end


### PR DESCRIPTION
# Bug fix

## Description

This is a PR changes the way futurism's `default_controller` is resolved. Previously, you could only set as a constant (i.e. `MyController`), but now you can set as `"MyController"` and it will be converted to the constant upon use.  This is to address a zietwork autoload issue as outlined in #68 

NOTE: This is a commit that is based on #69 and shouldn't be merged until that PR is merged.

Fixes #68 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
