### PR TITLE
Allow rendered partials to use the `partial_counter` variable

### DIFF
--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -28,8 +28,8 @@ module Futurism
       else
         collection_class_name = collection.klass.name
         as = options.delete(:as) || collection_class_name.downcase
-        collection.map { |record|
-          Element.new(extends: extends, placeholder: placeholder, options: options.deep_merge(locals: {as.to_sym => record})).render
+        collection.each_with_index.map { |record, index|
+          Element.new(extends: extends, placeholder: placeholder, options: options.deep_merge(locals: {as.to_sym => record, "#{as}_counter".to_sym => index})).render
         }.join.html_safe
       end
     end

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -115,8 +115,8 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
       subscribe
 
       mock_renderer
-        .expect(:render, "<tag></tag>", [partial: "posts/card", locals: {post: Post.first, important_local: "needed to render"}])
-        .expect(:render, "<tag></tag>", [partial: "posts/card", locals: {post: Post.last, important_local: "needed to render"}])
+        .expect(:render, "<tag></tag>", [partial: "posts/card", locals: {post: Post.first, important_local: "needed to render", post_counter: 0}])
+        .expect(:render, "<tag></tag>", [partial: "posts/card", locals: {post: Post.last, important_local: "needed to render", post_counter: 1}])
 
       signed_params = fragment.children.first["data-signed-params"]
       perform :receive, {"signed_params" => [signed_params]}
@@ -135,11 +135,11 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
       fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, as: :post_item, extends: :div) {})
       subscribe
 
-      mock_renderer.expect(:render, "<tag></tag>", [partial: "posts/card", locals: {post_item: Post.first}])
+      mock_renderer.expect(:render, "<tag></tag>", [partial: "posts/card", locals: {post_item: Post.first, post_item_counter: 0}])
       signed_params = fragment.children.first["data-signed-params"]
       perform :receive, {"signed_params" => [signed_params]}
 
-      mock_renderer.expect(:render, "<tag></tag>", [partial: "posts/card", locals: {post_item: Post.last}])
+      mock_renderer.expect(:render, "<tag></tag>", [partial: "posts/card", locals: {post_item: Post.last, post_item_counter: 1}])
       signed_params = fragment.children.last["data-signed-params"]
       perform :receive, {"signed_params" => [signed_params]}
 


### PR DESCRIPTION
# Enhancement

## Description

Makes the `#{partial}_counter` variable available to futurized partials (cf https://guides.rubyonrails.org/layouts_and_rendering.html#local-variables)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
