### PR TITLE
Retry to resolve an element

### DIFF
--- a/javascript/elements/futurism_element.js
+++ b/javascript/elements/futurism_element.js
@@ -10,4 +10,8 @@ export default class FuturismElement extends HTMLElement {
     extendElementWithIntersectionObserver(this)
     extendElementWithEagerLoading(this)
   }
+
+  disconnectedCallback () {
+    clearInterval(this.retryTimeout)
+  }
 }

--- a/javascript/elements/futurism_li.js
+++ b/javascript/elements/futurism_li.js
@@ -10,4 +10,8 @@ export default class FuturismLI extends HTMLLIElement {
     extendElementWithIntersectionObserver(this)
     extendElementWithEagerLoading(this)
   }
+
+  disconnectedCallback () {
+    clearInterval(this.retryTimeout)
+  }
 }

--- a/javascript/elements/futurism_table_row.js
+++ b/javascript/elements/futurism_table_row.js
@@ -10,4 +10,8 @@ export default class FuturismTableRow extends HTMLTableRowElement {
     extendElementWithIntersectionObserver(this)
     extendElementWithEagerLoading(this)
   }
+
+  disconnectedCallback () {
+    clearInterval(this.retryTimeout)
+  }
 }

--- a/javascript/elements/futurism_utils.js
+++ b/javascript/elements/futurism_utils.js
@@ -22,7 +22,13 @@ const dispatchAppearEvent = (entry, observer = null) => {
 const observerCallback = (entries, observer) => {
   entries.forEach(entry => {
     if (!entry.isIntersecting) return
+
+    // give it a try, then start the interval
     dispatchAppearEvent(entry, observer)
+
+    entry.target.retryTimeout = setInterval(() => {
+      dispatchAppearEvent(entry, observer)
+    }, 3000)
   })
 }
 


### PR DESCRIPTION
# Enhancement
## Description

Wrapped the `dispatchAppearEvent(entry, observer)` in a `setInterval`, which is cleared upon disconnection. Note that there is a bit of a shotgun surgery here, which at the moment I don't know to avoid - but it's only 3 instances.

Also yet TODO is the configuration of the interval time. I suggest specifying this via a custom element attribute, which could be passed in by the `helper`.

Fixes #75 

## Why should this be added

Resilience to network conditions etc.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
