### PR TITLE
Better recognize urls

### DIFF
--- a/lib/futurism/resolver/controller/renderer.rb
+++ b/lib/futurism/resolver/controller/renderer.rb
@@ -34,7 +34,7 @@ module Futurism
             path = ActionDispatch::Journey::Router::Utils.normalize_path(uri.path)
             query_hash = Rack::Utils.parse_nested_query(uri.query)
 
-            path_params = recognize_path(url) # use full url to be more likely to match a url with subdomain constraints
+            path_params = recognize_url(url) # use full url to be more likely to match a url with subdomain constraints
 
             self.renderer =
               renderer.new(
@@ -56,7 +56,7 @@ module Futurism
           renderer.instance_variable_set(:@env, new_env)
         end
 
-        def recognize_path(url)
+        def recognize_url(url)
           HTTP_METHODS.each do |http_method|
             path = Rails.application.routes.recognize_path(url, method: http_method)
             return path if path

--- a/lib/futurism/resolver/controller/renderer.rb
+++ b/lib/futurism/resolver/controller/renderer.rb
@@ -64,9 +64,9 @@ module Futurism
             # Route not matched, try next
           end
 
-          warn "We were unable to find a matching rails route for '#{url}'. " +
-            "This may be because there are proc-based routing constraints for this particular url, or " +
-            "it truly is an unrecognizable url."
+          warn "We were unable to find a matching rails route for '#{url}'. " \
+               "This may be because there are proc-based routing constraints for this particular url, or " \
+               "it truly is an unrecognizable url."
 
           {}
         end

--- a/lib/futurism/resolver/controller/renderer.rb
+++ b/lib/futurism/resolver/controller/renderer.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 module Futurism
   module Resolver
     class Controller
       class Renderer
+        HTTP_METHODS = [:get, :post, :put, :patch, :delete]
+
         def self.for(controller:, connection:, url:, params:)
           new(controller: controller, connection: connection, url: url, params: params).renderer
         end
@@ -30,7 +34,7 @@ module Futurism
             path = ActionDispatch::Journey::Router::Utils.normalize_path(uri.path)
             query_hash = Rack::Utils.parse_nested_query(uri.query)
 
-            path_params = Rails.application.routes.recognize_path(path)
+            path_params = recognize_path(url) # use full url to be more likely to match a url with subdomain constraints
 
             self.renderer =
               renderer.new(
@@ -50,6 +54,21 @@ module Futurism
           # Warden or Devise
           new_env = connection.env.merge(renderer.instance_variable_get(:@env))
           renderer.instance_variable_set(:@env, new_env)
+        end
+
+        def recognize_path(url)
+          HTTP_METHODS.each do |http_method|
+            path = Rails.application.routes.recognize_path(url, method: http_method)
+            return path if path
+          rescue ActionController::RoutingError
+            # Route not matched, try next
+          end
+
+          warn "We were unable to find a matching rails route for '#{url}'. " +
+            "This may be because there are proc-based routing constraints for this particular url, or " +
+            "it truly is an unrecognizable url."
+
+          {}
         end
       end
     end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -2,5 +2,11 @@ Rails.application.routes.draw do
   resources :posts
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
+  put "/known/get", to: "home#get_action"
+  put "/known/put", to: "home#put_action"
+  patch "/known/patch", to: "home#patch_action"
+  delete "/known/delete", to: "home#delete_action"
+  post "/known/post", to: "home#post_action"
+
   root "home#index"
 end

--- a/test/resolver/controller/renderer_test.rb
+++ b/test/resolver/controller/renderer_test.rb
@@ -94,4 +94,27 @@ class Futurism::Resolver::Controller::RendererTest < ActiveSupport::TestCase
 
     assert_equal rendered_html, "<a href=\"/\">/posts/1</a>"
   end
+
+  ["get", "put", "patch", "post", "delete"].each do |http_method|
+    test "renderer.render handles an #{http_method} route" do
+      renderer = Futurism::Resolver::Controller::Renderer.for(controller: ApplicationController,
+                                                              connection: dummy_connection,
+                                                              url: "http://example.org/known/#{http_method}",
+                                                              params: {})
+
+      rendered_html = renderer.render(inline: "<%= request.url %>")
+      assert_equal rendered_html, "http://example.org/known/#{http_method}"
+    end
+  end
+
+  test "renderer.render handles an umatchable url" do
+    renderer = Futurism::Resolver::Controller::Renderer.for(controller: ApplicationController,
+                                                            connection: dummy_connection,
+                                                            url: "http://example.org/unknown/place",
+                                                            params: {})
+
+    assert_nothing_raised do
+      renderer.render(inline: "<%= request.url %>")
+    end
+  end
 end


### PR DESCRIPTION
# Bug fix

## Description

This passes in the full url to the `Rails.application.routes.recognize_path` method and try multiple HTTP methods to try to match a URL.

Note: While this does fix some bugs, it doesn't appear the `controller` and `action_name` are currently being passed through correctly to the underlying controller. I don't have failing tests for that, but it doesn't look like the code I wrote some time ago works properly. 

This PR does no harm -- it makes it better -- but it doesn't fully address the intended functionality. However, it does fix #89 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
