### PR TITLE
Support GlobalId objects

### DIFF
--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -82,7 +82,10 @@ module Futurism
         require_relative "shims/deep_transform_values" unless options.respond_to? :deep_transform_values
 
         options.deep_transform_values do |value|
-          value.is_a?(ActiveRecord::Base) && !value.new_record? ? value.to_global_id.to_s : value
+          next(value) unless value.respond_to?(:to_global_id)
+          next(value) if value.is_a?(ActiveRecord::Base) && value.new_record?
+
+          value.to_global_id.to_s
         end
       end
 

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Futurism::HelperTest < ActionView::TestCase
@@ -10,7 +12,7 @@ class Futurism::HelperTest < ActionView::TestCase
 
     assert_equal "futurism-element", element.children.first.name
     assert_equal post, GlobalID::Locator.locate_signed(element.children.first["data-sgid"])
-    assert_equal signed_params({data: {controller: "test"}}), element.children.first["data-signed-params"]
+    assert_equal sign_params({data: {controller: "test"}}), element.children.first["data-signed-params"]
     assert_nil element.children.first["data-eager"]
     assert_equal "absolute inset-0", element.children.first["class"]
 
@@ -20,7 +22,9 @@ class Futurism::HelperTest < ActionView::TestCase
     assert_equal "futurism-element", element.children.first.name
     assert_nil element.children.first["data-sgid"]
     assert_nil element.children.first["data-eager"]
-    assert_equal signed_params(params.merge({data: {action: "test#click"}})), element.children.first["data-signed-params"]
+    assert_equal "posts/card", extract_params(element.children.first["data-signed-params"])[:partial]
+    assert_equal post.to_global_id.to_s, extract_params(element.children.first["data-signed-params"])[:locals][:post]
+    assert_equal "test#click", extract_params(element.children.first["data-signed-params"])[:data][:action]
     assert_equal "flex justify-center", element.children.first["class"]
   end
 
@@ -39,15 +43,15 @@ class Futurism::HelperTest < ActionView::TestCase
     element = Nokogiri::HTML.fragment(futurize(post, extends: :div, html_options: {data: {controller: "test", sgid: "test", signed_params: "test"}}) {})
 
     assert_equal post, GlobalID::Locator.locate_signed(element.children.first["data-sgid"])
-    assert_equal signed_params({data: {controller: "test"}}), element.children.first["data-signed-params"]
+    assert_equal sign_params({data: {controller: "test"}}), element.children.first["data-signed-params"]
   end
 
-  test "allows to specify a new record" do
+  test "allows to specify a new ActiveRecord record" do
     post = Post.new
 
     element = Nokogiri::HTML.fragment(futurize("posts/form", post: post, extends: :div) {})
 
-    assert resource(signed_params: element.children.first["data-signed-params"], sgid: nil)[:locals][:post].new_record?
+    assert extract_params(element.children.first["data-signed-params"])[:locals][:post].new_record?
   end
 
   test "renders an eager loading data attribute" do
@@ -81,23 +85,15 @@ class Futurism::HelperTest < ActionView::TestCase
     assert_equal({action_item: "gid://dummy/ActionItem/2", action_item_counter: 1}, Futurism::MessageVerifier.message_verifier.verify(element.children.last["data-signed-params"])[:locals])
   end
 
-  def signed_params(params)
-    Rails.application.message_verifier("futurism").generate(transformed_options(params))
+  def verifier
+    Futurism::MessageVerifier.message_verifier
   end
 
-  def transformed_options(options)
-    options.deep_transform_values do |value|
-      value.is_a?(ActiveRecord::Base) && !value.new_record? ? value.to_global_id.to_s : value
-    end
+  def extract_params(params)
+    verifier.verify(params)
   end
 
-  def resource(signed_params:, sgid:)
-    return GlobalID::Locator.locate_signed(sgid) if sgid.present?
-
-    Rails
-      .application
-      .message_verifier("futurism")
-      .verify(signed_params)
-      .deep_transform_values { |value| value.is_a?(String) && value.start_with?("gid://") ? GlobalID::Locator.locate(value) : value }
+  def sign_params(params)
+    verifier.generate(params)
   end
 end

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -54,6 +54,26 @@ class Futurism::HelperTest < ActionView::TestCase
     assert extract_params(element.children.first["data-signed-params"])[:locals][:post].new_record?
   end
 
+  # PORO that is serializable/de-serializable
+  class GlobalIdableEntity
+    include GlobalID::Identification
+
+    def id
+      "fake-id"
+    end
+
+    def self.find(id)
+      new if id == "fake-id"
+    end
+  end
+
+  test "allows to specify any GlobalId-able entity" do
+    entity = GlobalIdableEntity.new
+    element = Nokogiri::HTML.fragment(futurize("posts/form", entity: entity, extends: :div) {})
+
+    assert_equal "gid://dummy/Futurism::HelperTest::GlobalIdableEntity/fake-id", extract_params(element.children.first["data-signed-params"])[:locals][:entity]
+  end
+
   test "renders an eager loading data attribute" do
     post = Post.create title: "Lorem"
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

## Description

Allows any local to be a GlobalId-able object

Fixes #91 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
