### PR TITLE
Use rails convention to underscore collection class names

### DIFF
--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -27,7 +27,7 @@ module Futurism
         Element.new(extends: extends, placeholder: placeholder, options: options).render
       else
         collection_class_name = collection.try(:klass).try(:name) || collection.first.class.to_s
-        as = options.delete(:as) || collection_class_name.downcase
+        as = options.delete(:as) || collection_class_name.underscore
         collection.each_with_index.map { |record, index|
           Element.new(extends: extends, placeholder: placeholder, options: options.deep_merge(locals: {as.to_sym => record, "#{as}_counter".to_sym => index})).render
         }.join.html_safe

--- a/test/dummy/app/models/action_item.rb
+++ b/test/dummy/app/models/action_item.rb
@@ -1,0 +1,2 @@
+class ActionItem < ApplicationRecord
+end

--- a/test/dummy/db/migrate/2021042923813_create_action_items.rb
+++ b/test/dummy/db/migrate/2021042923813_create_action_items.rb
@@ -1,0 +1,9 @@
+class CreateActionItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_items do |t|
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -11,9 +11,17 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_07_11_122838) do
+
+  create_table "action_items", force: :cascade do |t|
+    t.string "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "posts", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
+
 end

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -24,6 +24,15 @@ class Futurism::HelperTest < ActionView::TestCase
     assert_equal "flex justify-center", element.children.first["class"]
   end
 
+  test "renders html options with data attributes with multi-word object" do
+    action_item = ActionItem.create description: "Do this"
+
+    element = Nokogiri::HTML.fragment(futurize(action_item, extends: :div) {})
+
+    assert_equal "futurism-element", element.children.first.name
+    assert_equal action_item, GlobalID::Locator.locate_signed(element.children.first["data-sgid"])
+  end
+
   test "ensures signed_params and sgid are not overwritable" do
     post = Post.create title: "Lorem"
 
@@ -50,6 +59,26 @@ class Futurism::HelperTest < ActionView::TestCase
 
     element = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}, eager: true, extends: :div) {})
     assert_equal "true", element.children.first["data-eager"]
+  end
+
+  test "renders a collection " do
+    Post.create title: "Lorem"
+    Post.create title: "Lorem2"
+
+    element = Nokogiri::HTML.fragment(futurize(collection: Post.all, extends: :div) {})
+
+    assert_equal({post: "gid://dummy/Post/1", post_counter: 0}, Futurism::MessageVerifier.message_verifier.verify(element.children.first["data-signed-params"])[:locals])
+    assert_equal({post: "gid://dummy/Post/2", post_counter: 1}, Futurism::MessageVerifier.message_verifier.verify(element.children.last["data-signed-params"])[:locals])
+  end
+
+  test "renders a collection with multi-word object" do
+    ActionItem.create description: "Do this"
+    ActionItem.create description: "Do that"
+
+    element = Nokogiri::HTML.fragment(futurize(collection: ActionItem.all, extends: :div) {})
+
+    assert_equal({action_item: "gid://dummy/ActionItem/1", action_item_counter: 0}, Futurism::MessageVerifier.message_verifier.verify(element.children.first["data-signed-params"])[:locals])
+    assert_equal({action_item: "gid://dummy/ActionItem/2", action_item_counter: 1}, Futurism::MessageVerifier.message_verifier.verify(element.children.last["data-signed-params"])[:locals])
   end
 
   def signed_params(params)


### PR DESCRIPTION
# Bug Fix

## Description

This would mean an object such as `ActionItem` when evaluated in a partial would show up as `actionitem` by default, instead of the expected `action_item`. Users of the library could override this with the `as:` option, such as `as: :action_item` in this case.

Prior to the change, this code would be need:

```erb
<!-- index.html.erb --!>
<%= futurize(collection: ActionItem.all, extends: :div)  { } %>

<!-- _action_item.html.erb --!>
<%= actionitem.description %>
```

Whereas, we would expect the following to work
```erb
<!-- index.html.erb --!>
<%= futurize(collection: ActionItem.all, extends: :div)  { } %>

<!-- _action_item.html.erb --!>
<%= action_item.description %>
```

## Why should this be added

This follows Rails conventions and the principle of least surprise. However, this is a breaking change for users of this library, but is correct in following Rails conventions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
