### PR TITLE
Better errors

### DIFF
--- a/lib/futurism.rb
+++ b/lib/futurism.rb
@@ -21,7 +21,10 @@ module Futurism
     (@@default_controller || "::ApplicationController").to_s.constantize
   end
 
-  ActiveSupport.on_load(:action_view) {
+  ActiveSupport.on_load(:action_view) do
     include Futurism::Helpers
-  }
+  end
+
+  mattr_accessor :logger
+  self.logger ||= Rails.logger ? Rails.logger.new : Logger.new($stdout)
 end

--- a/lib/futurism/resolver/resources.rb
+++ b/lib/futurism/resolver/resources.rb
@@ -26,7 +26,7 @@ module Futurism
             begin
               renderer.render(resource)
             rescue => exception
-              error_render.render(exception)
+              error_renderer.render(exception)
             end
 
           yield(resource_definition.selector, html)
@@ -35,7 +35,7 @@ module Futurism
 
       private
 
-      def error_render
+      def error_renderer
         ErrorRenderer.new
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,3 +9,6 @@ require "pry"
 
 # Filter out the backtrace from minitest while preserving the one from other libraries.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
+
+# Turn off logger output as to not have poor test output
+Futurism.logger = Logger.new(IO::NULL)


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

## Description

In development and test, we render a short version of the error message (and a hidden backtrace) to be able to catch typos, bugs in our partials, etc.

Fixes #63 

## Why should this be added

While developing you're not often watching the logs to see what's happening. This will output a fairly obvious error message and the backtrace is hidden (via `display: none;`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
