### PR TITLE
Broadcast_each

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Lazy-load Rails partials via CableReady
   - [Explicit Partial](#explicit-partial)
   - [HTML Options](#html-options)
   - [Eager Loading](#eager-loading)
+  - [Broadcast Partials Individually](#broadcast-partials-individually)
 - [Events](#events)
 - [Installation](#installation)
   - [Manual Installation](#manual-installation)
@@ -169,6 +170,19 @@ Futurism makes that dead simple:
 
 ```erb
 <%= futurize 'some_tab', eager: true, extends: :tr do %>
+  <div class="placeholder"</td>
+<% end %>
+```
+
+### Broadcast Partials Individually
+Futurism's default behavior is to `broadcast` partials as they are generated in batches: 
+
+On the client side, `IntersectionObserver` events are triggered in a debounced fashion, so several `render`s are performed on the server for each of those events. By default, futurism will group those to a single `broadcast` call (to save server CPU time).
+
+For collections, however, you can opt into individual broadcasts by specifying `broadcast_each: true` in your helper usage:
+
+```erb
+<%= futurize @posts, broadcast_each: true, extends: :tr do %>
   <div class="placeholder"</td>
 <% end %>
 ```

--- a/javascript/futurism_channel.js
+++ b/javascript/futurism_channel.js
@@ -30,7 +30,7 @@ export const createSubscription = consumer => {
               e => e.target.dataset.signedController
             ),
             urls: events.map(_ => window.location.href),
-            broadcast_each: events.some(e => e.target.dataset.broadcastEach)
+            broadcast_each: events.map(e => e.target.dataset.broadcastEach)
           })
         })
       )

--- a/javascript/futurism_channel.js
+++ b/javascript/futurism_channel.js
@@ -18,7 +18,7 @@ const debounceEvents = (callback, delay = 20) => {
 
 export const createSubscription = consumer => {
   consumer.subscriptions.create('Futurism::Channel', {
-    connected() {
+    connected () {
       window.Futurism = this
       document.addEventListener(
         'futurism:appear',
@@ -26,14 +26,17 @@ export const createSubscription = consumer => {
           this.send({
             signed_params: events.map(e => e.target.dataset.signedParams),
             sgids: events.map(e => e.target.dataset.sgid),
-            signed_controllers: events.map(e => e.target.dataset.signedController),
-            urls: events.map(_ => window.location.href)
+            signed_controllers: events.map(
+              e => e.target.dataset.signedController
+            ),
+            urls: events.map(_ => window.location.href),
+            broadcast_each: events.some(e => e.target.dataset.broadcastEach)
           })
         })
       )
     },
 
-    received(data) {
+    received (data) {
       if (data.cableReady) {
         CableReady.perform(data.operations, {
           emitMissingElementWarnings: false

--- a/lib/futurism/channel.rb
+++ b/lib/futurism/channel.rb
@@ -15,14 +15,16 @@ module Futurism
     end
 
     def receive(data)
-      resources = data.fetch_values("signed_params", "sgids", "signed_controllers", "urls") { |_key| Array.new(data["signed_params"].length, nil) }.transpose
+      resources = data.fetch_values("signed_params", "sgids", "signed_controllers", "urls", "broadcast_each") { |_key| Array.new(data["signed_params"].length, nil) }.transpose
 
       resolver = Resolver::Resources.new(resource_definitions: resources, connection: connection, params: @params)
-      resolver.resolve do |selector, html|
+      resolver.resolve do |selector, html, broadcast_each|
         cable_ready[stream_name].outer_html(
           selector: selector,
           html: html
         )
+
+        cable_ready.broadcast if broadcast_each
       end
 
       cable_ready.broadcast

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -32,8 +32,12 @@ module Futurism
       else
         collection_class_name = collection.try(:klass).try(:name) || collection.first.class.to_s
         as = options.delete(:as) || collection_class_name.underscore
+        broadcast_each = options.delete(:broadcast_each) || false
         collection.each_with_index.map { |record, index|
-          WrappingFuturismElement.new(extends: extends, placeholder: placeholder, options: options.deep_merge(locals: {as.to_sym => record, "#{as}_counter".to_sym => index})).render
+          WrappingFuturismElement.new(extends: extends, placeholder: placeholder, options: options.deep_merge(
+            broadcast_each: broadcast_each,
+            locals: {as.to_sym => record, "#{as}_counter".to_sym => index}
+          )).render
         }.join.html_safe
       end
     end
@@ -49,12 +53,13 @@ module Futurism
       include ActionView::Helpers
       include Futurism::MessageVerifier
 
-      attr_reader :extends, :placeholder, :html_options, :data_attributes, :model, :options, :eager, :controller
+      attr_reader :extends, :placeholder, :html_options, :data_attributes, :model, :options, :eager, :broadcast_each, :controller
 
       def initialize(extends:, placeholder:, options:)
         @extends = extends
         @placeholder = placeholder
         @eager = options.delete(:eager)
+        @broadcast_each = options.delete(:broadcast_each)
         @controller = options.delete(:controller)
         @html_options = options.delete(:html_options) || {}
         @data_attributes = html_options.fetch(:data, {}).except(:sgid, :signed_params)
@@ -67,6 +72,7 @@ module Futurism
           signed_params: signed_params,
           sgid: model && model.to_sgid.to_s,
           eager: eager.presence,
+          broadcast_each: broadcast_each.presence,
           signed_controller: signed_controller
         })
       end

--- a/lib/futurism/resolver/resources.rb
+++ b/lib/futurism/resolver/resources.rb
@@ -3,7 +3,7 @@ module Futurism
     class Resources
       include Futurism::MessageVerifier
 
-      # resource definitions are an array of [signed_params, sgid, signed_controller, url]
+      # resource definitions are an array of [signed_params, sgid, signed_controller, url, broadcast_each]
       def initialize(resource_definitions:, connection:, params:)
         @connection = connection
         @params = params
@@ -16,7 +16,7 @@ module Futurism
         resolved_models.zip(@resources_with_sgids).each do |model, resource_definition|
           html = renderer_for(resource_definition: resource_definition).render(model)
 
-          yield(resource_definition.selector, html)
+          yield(resource_definition.selector, html, resource_definition.broadcast_each)
         end
 
         @resources_without_sgids.each do |resource_definition|
@@ -29,7 +29,7 @@ module Futurism
               error_renderer.render(exception)
             end
 
-          yield(resource_definition.selector, html)
+          yield(resource_definition.selector, html, resource_definition.broadcast_each)
         end
       end
 
@@ -43,7 +43,7 @@ module Futurism
         attr_reader :signed_params, :sgid, :signed_controller, :url
 
         def initialize(resource_definition)
-          @signed_params, @sgid, @signed_controller, @url = resource_definition
+          @signed_params, @sgid, @signed_controller, @url, @broadcast_each = resource_definition
         end
 
         def selector
@@ -54,6 +54,10 @@ module Futurism
 
         def controller
           Resolver::Controller.from(signed_string: @signed_controller)
+        end
+
+        def broadcast_each
+          @broadcast_each == "true"
         end
       end
 

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -228,8 +228,8 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     subscribe(channel: "Futurism::Channel")
 
     assert_cable_ready_operation_on("Futurism::Channel:1", operation: "outerHtml",
-                                    selector: "[data-signed-params='#{signed_params}']",
-                                    html: "<div class=\"card\">\n  Lorem\n  <a href=\"/posts/1/edit\">Edit</a>\n</div>\n") do
+                                                           selector: "[data-signed-params='#{signed_params}']",
+                                                           html: "<div class=\"card\">\n  Lorem\n  <a href=\"/posts/1/edit\">Edit</a>\n</div>\n") do
       perform :receive, {"signed_params" => [signed_params]}
     end
   end
@@ -257,8 +257,8 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     subscribe(channel: "Futurism::Channel")
 
     assert_cable_ready_operation_on("Futurism::Channel:1", operation: "outerHtml",
-                                    selector: "[data-signed-params='#{signed_params}']",
-                                    html: /Missing partial INVALID\/_PARTIAL/) do
+                                                           selector: "[data-signed-params='#{signed_params}']",
+                                                           html: /Missing partial INVALID\/_PARTIAL/) do
       perform :receive, {"signed_params" => [signed_params]}
     end
   end
@@ -270,8 +270,8 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     subscribe(channel: "Futurism::Channel")
 
     assert_cable_ready_operation_on("Futurism::Channel:1", operation: "outerHtml",
-                                    selector: "[data-signed-params='#{signed_params}']",
-                                    html: /undefined local variable or method/) do
+                                                           selector: "[data-signed-params='#{signed_params}']",
+                                                           html: /undefined local variable or method/) do
       perform :receive, {"signed_params" => [signed_params]}
     end
   end
@@ -281,9 +281,9 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
       "cableReady" => true,
       "operations" => {
         operation => [{
-                        "selector" => selector,
-                        "html" => html
-                      }]
+          "selector" => selector,
+          "html" => html
+        }]
       }
     }
 

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -8,6 +8,31 @@ def with_mocked_renderer
   end
 end
 
+def with_mocked_cable_ready
+  cable_ready_mock = MiniTest::Mock.new
+  cable_ready_channel = MiniTest::Mock.new
+  cable_ready_channel.expect(:outer_html, nil, [Hash])
+  cable_ready_channel.expect(:outer_html, nil, [Hash])
+
+  cable_ready_mock.expect(:[], cable_ready_channel, ["1"])
+  cable_ready_mock.expect(:[], cable_ready_channel, ["1"])
+  cable_ready_mock.expect(:broadcast, nil)
+  cable_ready_mock.expect(:broadcast, nil)
+  cable_ready_mock.expect(:broadcast, nil)
+
+  CableReady::Broadcaster.alias_method(:orig_cable_ready, :cable_ready)
+
+  CableReady::Broadcaster.define_method(:cable_ready) do
+    cable_ready_mock
+  end
+
+  yield cable_ready_mock
+
+  CableReady::Broadcaster.undef_method(:cable_ready)
+
+  CableReady::Broadcaster.alias_method(:cable_ready, :orig_cable_ready)
+end
+
 class Futurism::ChannelTest < ActionCable::Channel::TestCase
   include Futurism::Helpers
   include ActionView::Helpers
@@ -169,6 +194,23 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "broadcasts elements of a collection immediately" do
+    with_mocked_cable_ready do |cable_ready_mock|
+      Post.create title: "Lorem"
+      Post.create title: "Ipsum"
+      fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, broadcast_each: true, extends: :div, locals: {important_local: "needed to render"}) {})
+      subscribe
+
+      signed_params_1 = fragment.children.first["data-signed-params"]
+      broadcast_each_1 = fragment.children.first["data-broadcast-each"]
+      signed_params_2 = fragment.children.last["data-signed-params"]
+      broadcast_each_2 = fragment.children.last["data-broadcast-each"]
+      perform :receive, {"signed_params" => [signed_params_1, signed_params_2], "broadcast_each" => [broadcast_each_1, broadcast_each_2]}
+
+      assert_mock cable_ready_mock
+    end
+  end
+
   test "broadcasts an inline rendered text" do
     fragment = Nokogiri::HTML.fragment(futurize(inline: "<%= 1 + 2 %>", extends: :div) {})
     signed_params = fragment.children.first["data-signed-params"]
@@ -186,8 +228,8 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     subscribe(channel: "Futurism::Channel")
 
     assert_cable_ready_operation_on("Futurism::Channel:1", operation: "outerHtml",
-                                                           selector: "[data-signed-params='#{signed_params}']",
-                                                           html: "<div class=\"card\">\n  Lorem\n  <a href=\"/posts/1/edit\">Edit</a>\n</div>\n") do
+                                    selector: "[data-signed-params='#{signed_params}']",
+                                    html: "<div class=\"card\">\n  Lorem\n  <a href=\"/posts/1/edit\">Edit</a>\n</div>\n") do
       perform :receive, {"signed_params" => [signed_params]}
     end
   end
@@ -215,8 +257,8 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     subscribe(channel: "Futurism::Channel")
 
     assert_cable_ready_operation_on("Futurism::Channel:1", operation: "outerHtml",
-                                                           selector: "[data-signed-params='#{signed_params}']",
-                                                           html: /Missing partial INVALID\/_PARTIAL/) do
+                                    selector: "[data-signed-params='#{signed_params}']",
+                                    html: /Missing partial INVALID\/_PARTIAL/) do
       perform :receive, {"signed_params" => [signed_params]}
     end
   end
@@ -228,8 +270,8 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     subscribe(channel: "Futurism::Channel")
 
     assert_cable_ready_operation_on("Futurism::Channel:1", operation: "outerHtml",
-                                                           selector: "[data-signed-params='#{signed_params}']",
-                                                           html: /undefined local variable or method/) do
+                                    selector: "[data-signed-params='#{signed_params}']",
+                                    html: /undefined local variable or method/) do
       perform :receive, {"signed_params" => [signed_params]}
     end
   end
@@ -239,9 +281,9 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
       "cableReady" => true,
       "operations" => {
         operation => [{
-          "selector" => selector,
-          "html" => html
-        }]
+                        "selector" => selector,
+                        "html" => html
+                      }]
       }
     }
 
@@ -271,8 +313,8 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
 
     message.dig("cableReady") == true &&
       (matcher_operation.dig("selector") === message_operation.dig("selector") ||
-        matcher_operation.dig("selector").match(message_operation.dig("selector"))) &&
+       matcher_operation.dig("selector").match(message_operation.dig("selector"))) &&
       (matcher_operation.dig("html") === message_operation.dig("html") ||
-        matcher_operation.dig("html").match(message_operation.dig("html")))
+       matcher_operation.dig("html").match(message_operation.dig("html")))
   end
 end

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -96,7 +96,7 @@ class Futurism::HelperTest < ActionView::TestCase
     assert_equal "true", element.children.first["data-eager"]
   end
 
-  test "renders a collection " do
+  test "renders a collection" do
     Post.create title: "Lorem"
     Post.create title: "Lorem2"
 
@@ -114,6 +114,16 @@ class Futurism::HelperTest < ActionView::TestCase
 
     assert_equal({action_item: "gid://dummy/ActionItem/1", action_item_counter: 0}, Futurism::MessageVerifier.message_verifier.verify(element.children.first["data-signed-params"])[:locals])
     assert_equal({action_item: "gid://dummy/ActionItem/2", action_item_counter: 1}, Futurism::MessageVerifier.message_verifier.verify(element.children.last["data-signed-params"])[:locals])
+  end
+
+  test "renders a collection of items with a broadcast_each attribute" do
+    Post.create title: "Lorem"
+    Post.create title: "Lorem2"
+
+    element = Nokogiri::HTML.fragment(futurize(collection: Post.all, broadcast_each: true, extends: :div) {})
+
+    assert_equal "true", element.children.first["data-broadcast-each"]
+    assert_equal "true", element.children.last["data-broadcast-each"]
   end
 
   def verifier


### PR DESCRIPTION
# Feature

## Description

Allows to define an option called `broadcast_each` on a collection that will issue individual `cable_ready.broadcast` calls for each element

Closes #79


